### PR TITLE
server: Dockerfile / docker-compose 追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.claude/
+.DS_Store

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  server:
+    build: ./server
+    ports:
+      - "8080:8080"
+    restart: unless-stopped

--- a/server/.dockerignore
+++ b/server/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.gitignore
+*.md
+Dockerfile
+.dockerignore

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:1.22-alpine AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /out/server ./cmd/server
+
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=build /out/server /server
+EXPOSE 8080
+USER nonroot:nonroot
+ENTRYPOINT ["/server"]


### PR DESCRIPTION
## Summary
- AWS Fargate/ECS デプロイ（仕様書 §13）を見据え、`server` を Docker 化
- multi-stage build + distroless でイメージ約 7MB、非 root 実行
- ローカル開発用に `docker-compose.yml` も追加

## 変更内容
- `server/Dockerfile` — `golang:1.22-alpine` でビルド → `distroless/static-debian12:nonroot` にコピー
- `server/.dockerignore` — ビルドコンテキスト削減
- `docker-compose.yml` — `docker compose up` で 8080 起動
- `.gitignore` — `.claude/` などローカル生成物を除外

## Test plan
- [x] `docker build` 成功（イメージサイズ 7.19MB）
- [x] `docker run -p 8080:8080` で起動 → tick ログ確認
- [x] `docker compose up` で起動 → 同様に動作確認
- [ ] ECR push / Fargate デプロイは Person 5 の作業で別途検証

## 依存
PR #3 (yutoAb/game-logic) に依存。先に #3 をマージしてから本 PR を進めてください。

Refs: #2