### PR TITLE
Add: Dockerfile / docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.gitignore
+.github
+.claude
+.DS_Store
+docs
+infra
+README.md
+Dockerfile
+docker-compose.yml
+.dockerignore
+
+client/node_modules
+client/dist
+server/samezario-server
+server/internal/static/assets/*
+!server/internal/static/assets/.gitkeep

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ server/internal/static/assets/*
 # Editor
 .vscode/
 .idea/
+.claude/
 
 # OS
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:20-alpine AS client
+WORKDIR /client
+COPY client/package.json client/package-lock.json ./
+RUN npm ci
+COPY client/ ./
+RUN npm run build
+
+FROM golang:1.22-alpine AS server
+WORKDIR /src
+COPY server/go.mod server/go.sum ./
+RUN go mod download
+COPY server/ ./
+COPY --from=client /client/dist/ ./internal/static/assets/
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -trimpath -o /out/samezario-server ./cmd/server
+
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=server /out/samezario-server /samezario-server
+EXPOSE 8080
+USER nonroot:nonroot
+ENTRYPOINT ["/samezario-server"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+services:
+  samezario:
+    build: .
+    ports:
+      - "8080:8080"
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- ローカル開発＆将来的な AWS デプロイを見据え、リポジトリを Docker 化
- `docker compose up` ひとつでクライアント (Phaser) とサーバー (Go) 込みの単一バイナリが :8080 で起動

## 変更内容
- **Dockerfile**（ルート配置）: 3-stage build
  1. `node:20-alpine` で `client/` を `npm run build`
  2. `golang:1.22-alpine` で dist を `server/internal/static/assets/` にコピー → `go build ./cmd/server`
  3. `gcr.io/distroless/static-debian12:nonroot` で実行
- **docker-compose.yml**（ルート）: `docker compose up -d` で起動
- **.dockerignore**: `node_modules` / `dist` / `.git` / `infra` / `docs` を除外
- **.gitignore**: `.claude/` を追記

## メリット
- **イメージ約 9MB**（distroless + strip + trimpath）
- **非 root 実行**
- `build.sh` と同等の成果物を 1 コマンドで再現可能
- AWS 側で ECR に push → Fargate / ECS で運用可能（インフラ担当と別途調整）

## Test plan
- [x] `docker build -t samezario:dev .` 成功（サイズ 8.96MB）
- [x] `docker compose up -d` 起動
- [x] `GET /healthz` → 200
- [x] `GET /` → 200（埋め込み済みクライアントが配信される）
- [x] ブラウザで `http://localhost:8080/` からプレイ可能

## 既存インフラとの関係
- `infra/deploy.sh`（EC2 + systemd）には触れていません
- 既存の `server/build.sh` も残しています（ローカルでバイナリ単体を作りたい人向け）