### PR TITLE
Person 1: サメの進化系統（ルート）選択機能の実装とビジュアル強化

### DIFF
--- a/client/src/game/objects/Shark.ts
+++ b/client/src/game/objects/Shark.ts
@@ -122,7 +122,7 @@ export class Shark extends Phaser.GameObjects.Container {
     }
 
     if (changedAppearance) {
-        this.updateColors();
+      this.updateColors();
     }
 
     /* rigid head segments (hardly bend) */

--- a/client/src/game/objects/Shark.ts
+++ b/client/src/game/objects/Shark.ts
@@ -1,9 +1,16 @@
 import Phaser from "phaser";
+import { SharkRoute } from "../../network/protocol";
 
 /* ── colours tuned to look like semi-transparent grey
       silhouettes against the dark ocean ──────────────────── */
 const BODY_COLORS = [0x708898, 0x668090, 0x5c7488, 0x526880, 0x485c78];
 const SIZE_SCALES = [1.3, 1.45, 1.6, 1.8, 2.05];
+
+const ROUTE_GLOW_COLORS: Record<SharkRoute, number> = {
+  "attack": 0xff6666,     // UIと同じ赤
+  "non-attack": 0x66ccff, // UIと同じ青
+  "deep-sea": 0xbb66ff    // UIと同じ紫
+};
 
 const SEGMENT_COUNT = 24;
 const BASE_SPACING = 5.5;
@@ -13,6 +20,7 @@ export class Shark extends Phaser.GameObjects.Container {
   private nameText: Phaser.GameObjects.Text;
 
   private stage = 0;
+  private route: SharkRoute = "attack";
   private isSelf: boolean;
   private sharkName = "";
 
@@ -60,9 +68,20 @@ export class Shark extends Phaser.GameObjects.Container {
 
   private updateColors() {
     if (!this.rope) return;
+    // 1. Base tint (grey silhouette)
     const color = BODY_COLORS[this.stage] ?? BODY_COLORS[0];
     const tint = this.isSelf ? color : 0x5a7a8e;
     this.rope.setColors(tint);
+
+    // 2. Route specific glow using Phaser's standard postFX
+    if (this.rope.postFX) {
+      this.rope.postFX.clear();
+      // Increase padding to ensure the outer glow doesn't get clipped by the bounds
+      this.rope.postFX.setPadding(32);
+      const glowColor = ROUTE_GLOW_COLORS[this.route];
+      // addGlow(color, outerStrength, innerStrength, knockout, threshold, distance)
+      this.rope.postFX.addGlow(glowColor, 4, 0, false, 0.1, 10);
+    }
   }
 
   /* slow powerful tail undulation */
@@ -78,6 +97,7 @@ export class Shark extends Phaser.GameObjects.Container {
     angle: number,
     stage: number,
     t: number,
+    route: SharkRoute,
     name?: string,
   ): void {
     this.targetX = x;
@@ -89,10 +109,20 @@ export class Shark extends Phaser.GameObjects.Container {
       this.nameText.setText(name);
     }
 
+    let changedAppearance = false;
     if (stage !== this.stage) {
       this.stage = stage;
       this.setScale(SIZE_SCALES[stage] ?? 1);
-      this.updateColors();
+      changedAppearance = true;
+    }
+    
+    if (route !== this.route) {
+      this.route = route;
+      changedAppearance = true;
+    }
+
+    if (changedAppearance) {
+        this.updateColors();
     }
 
     /* rigid head segments (hardly bend) */
@@ -135,13 +165,14 @@ export class Shark extends Phaser.GameObjects.Container {
       const norm = sa + Math.PI / 2;
 
       // Convert to local coordinates within the container
-      pts.push(new Phaser.Math.Vector2(
-        sp.x + Math.cos(norm) * wave - this.targetX,
-        sp.y + Math.sin(norm) * wave - this.targetY
-      ));
+      const lx = sp.x + Math.cos(norm) * wave - this.targetX;
+      const ly = sp.y + Math.sin(norm) * wave - this.targetY;
+      
+      pts.push(new Phaser.Math.Vector2(lx, ly));
     }
 
     this.rope.setPoints(pts);
+    
     this.setPosition(this.targetX, this.targetY);
   }
 }

--- a/client/src/game/scenes/GameScene.ts
+++ b/client/src/game/scenes/GameScene.ts
@@ -8,6 +8,7 @@ import type {
   LeaderboardPayload,
   StateSharkView,
   StateFoodView,
+  SharkRoute,
 } from "../../network/protocol";
 import { Shark } from "../objects/Shark";
 import { Food } from "../objects/Food";
@@ -16,13 +17,12 @@ import { InputController } from "../input";
 /* ── constants ─────────────────────────────────────────────── */
 const STAGE_THRESHOLDS = [0, 10, 25, 50, 100];
 const STAGE_ZOOMS = [1.0, 0.93, 0.88, 0.82, 0.76];
-const STAGE_NAMES = [
-  "シュモクザメ",
-  "イタチザメ",
-  "アオザメ",
-  "ホオジロザメ",
-  "メガロドン",
-];
+
+const ROUTE_STAGE_NAMES: Record<SharkRoute, string[]> = {
+  "attack": ["シュモクザメ", "イタチザメ", "アオザメ", "ホオジロザメ", "メガロドン"],
+  "non-attack": ["ドチザメ", "ネムリブカ", "シロワニ", "ウバザメ", "ジンベエザメ"],
+  "deep-sea": ["ツラナガコビトザメ", "ノコギリザメ", "ラブカ", "ミツクリザメ", "ニシオンデンザメ"]
+};
 
 const RADAR_R = 90;
 const RADAR_RANGE = 1400;
@@ -35,6 +35,16 @@ function hash(n: number): number {
   return s - Math.floor(s);
 }
 
+// Dummy route generator based on string hash
+function getDummyRoute(id: string): SharkRoute {
+  let h = 0;
+  for (let i = 0; i < id.length; i++) {
+    h = Math.imul(31, h) + id.charCodeAt(i) | 0;
+  }
+  const routes: SharkRoute[] = ["attack", "non-attack", "deep-sea"];
+  return routes[Math.abs(h) % routes.length];
+}
+
 /* ═══════════════════════════════════════════════════════════ */
 export class GameScene extends Phaser.Scene {
   /* world */
@@ -42,6 +52,7 @@ export class GameScene extends Phaser.Scene {
   private worldH = 4000;
   private myId = "";
   private myName = "";
+  private myRoute: SharkRoute = "attack";
 
   /* entities */
   private sharks = new Map<string, Shark>();
@@ -88,8 +99,9 @@ export class GameScene extends Phaser.Scene {
     super({ key: "GameScene" });
   }
 
-  init(data: { name: string }): void {
+  init(data: { name: string; route: SharkRoute }): void {
     this.myName = data.name;
+    this.myRoute = data.route;
   }
 
   preload(): void {
@@ -129,7 +141,7 @@ export class GameScene extends Phaser.Scene {
     });
     this.uiContainer.add(this.scoreText);
 
-    this.stageText = this.add.text(22, 70, STAGE_NAMES[0], {
+    this.stageText = this.add.text(22, 70, ROUTE_STAGE_NAMES[this.myRoute][0], {
       fontFamily: "system-ui, sans-serif",
       fontSize: "11px",
       color: "#556677",
@@ -534,6 +546,11 @@ export class GameScene extends Phaser.Scene {
   }
 
   private onState(m: StatePayload): void {
+    // 確実に自分自身のIDを更新・保持する
+    if (m.you && m.you.id) {
+        this.myId = m.you.id;
+    }
+
     if (m.full) {
       this.applyFullState(m);
     } else {
@@ -568,7 +585,7 @@ export class GameScene extends Phaser.Scene {
         isMax ? "MAX LEVEL" : `${m.you.xp} / ${threshold} XP`,
       );
       this.stageText.setText(
-        STAGE_NAMES[Math.min(m.you.stage, STAGE_NAMES.length - 1)],
+        ROUTE_STAGE_NAMES[this.myRoute][Math.min(m.you.stage, ROUTE_STAGE_NAMES[this.myRoute].length - 1)],
       );
     }
   }
@@ -578,12 +595,15 @@ export class GameScene extends Phaser.Scene {
     for (const v of m.sharks ?? []) {
       seen.add(v.id);
       let s = this.sharks.get(v.id);
+      const isSelf = v.id === this.myId;
       if (!s) {
-        s = new Shark(this, v.x, v.y, v.id === this.myId);
+        s = new Shark(this, v.x, v.y, isSelf);
         this.sharks.set(v.id, s);
         this.worldContainer.add(s);
       }
-      s.updateFromState(v.x, v.y, v.angle, v.stage, this.time.now, v.name);
+      // 強制的に自分のサメには自分が選択したルートを適用する
+      const route = isSelf ? this.myRoute : (v.route ?? getDummyRoute(v.id));
+      s.updateFromState(v.x, v.y, v.angle, v.stage, this.time.now, route, v.name);
     }
     for (const [id, s] of this.sharks) {
       if (!seen.has(id)) {
@@ -633,12 +653,15 @@ export class GameScene extends Phaser.Scene {
 
   private upsertShark(v: StateSharkView): void {
     let s = this.sharks.get(v.id);
+    const isSelf = v.id === this.myId;
     if (!s) {
-      s = new Shark(this, v.x, v.y, v.id === this.myId);
+      s = new Shark(this, v.x, v.y, isSelf);
       this.sharks.set(v.id, s);
       this.worldContainer.add(s);
     }
-    s.updateFromState(v.x, v.y, v.angle, v.stage, this.time.now, v.name);
+    // 強制的に自分のサメには自分が選択したルートを適用する
+    const route = isSelf ? this.myRoute : (v.route ?? getDummyRoute(v.id));
+    s.updateFromState(v.x, v.y, v.angle, v.stage, this.time.now, route, v.name);
   }
 
   private removeShark(id: string): void {

--- a/client/src/game/scenes/GameScene.ts
+++ b/client/src/game/scenes/GameScene.ts
@@ -548,7 +548,7 @@ export class GameScene extends Phaser.Scene {
   private onState(m: StatePayload): void {
     // 確実に自分自身のIDを更新・保持する
     if (m.you && m.you.id) {
-        this.myId = m.you.id;
+      this.myId = m.you.id;
     }
 
     if (m.full) {

--- a/client/src/network/protocol.ts
+++ b/client/src/network/protocol.ts
@@ -8,7 +8,10 @@ export type BaseMessage<T extends string, P> = {
 };
 
 // Client → Server
-export type JoinMsg = BaseMessage<"join", { name: string; route: SharkRoute }>;
+export type JoinMsg = BaseMessage<"join", { 
+  name: string; 
+  route: SharkRoute; // TODO: Server-side support is pending. Currently ignored by the server.
+}>;
 export type InputMsg = BaseMessage<"input", { angle: number; dash: boolean }>;
 export type ClientMsg = JoinMsg | InputMsg;
 
@@ -26,7 +29,7 @@ export interface StateSharkView {
   y: number;
   angle: number;
   stage: number;
-  route?: SharkRoute;
+  route?: SharkRoute; // TODO: Server-side support is pending. Not populated from the server; client uses fallback.
 }
 
 export interface StateFoodView {

--- a/client/src/network/protocol.ts
+++ b/client/src/network/protocol.ts
@@ -1,12 +1,14 @@
 // Mirrors server/internal/ws/message.go
 
+export type SharkRoute = "attack" | "non-attack" | "deep-sea";
+
 export type BaseMessage<T extends string, P> = {
   type: T;
   payload: P;
 };
 
 // Client → Server
-export type JoinMsg = BaseMessage<"join", { name: string }>;
+export type JoinMsg = BaseMessage<"join", { name: string; route: SharkRoute }>;
 export type InputMsg = BaseMessage<"input", { angle: number; dash: boolean }>;
 export type ClientMsg = JoinMsg | InputMsg;
 
@@ -24,6 +26,7 @@ export interface StateSharkView {
   y: number;
   angle: number;
   stage: number;
+  route?: SharkRoute;
 }
 
 export interface StateFoodView {

--- a/client/src/ui/screens/HomeScreen.ts
+++ b/client/src/ui/screens/HomeScreen.ts
@@ -1,9 +1,11 @@
 import Phaser from "phaser";
 import { net } from "../../network/websocket";
+import { SharkRoute } from "../../network/protocol";
 
 export class HomeScreen extends Phaser.Scene {
   private inputEl!: HTMLInputElement;
   private pendingName = "";
+  private selectedRoute: SharkRoute = "attack"; // Default route
 
   constructor() {
     super({ key: "HomeScreen" });
@@ -14,7 +16,7 @@ export class HomeScreen extends Phaser.Scene {
     this.cameras.main.setBackgroundColor("#001b44");
 
     this.add
-      .text(width / 2, height * 0.3, "サメザリオ", {
+      .text(width / 2, height * 0.25, "サメザリオ", {
         fontFamily: "system-ui",
         fontSize: "56px",
         color: "#88ccee",
@@ -22,7 +24,7 @@ export class HomeScreen extends Phaser.Scene {
       .setOrigin(0.5);
 
     this.add
-      .text(width / 2, height * 0.42, "Slither.io-style shark PoC", {
+      .text(width / 2, height * 0.35, "Slither.io-style shark PoC", {
         fontFamily: "system-ui",
         fontSize: "18px",
         color: "#6688aa",
@@ -40,7 +42,7 @@ export class HomeScreen extends Phaser.Scene {
     Object.assign(input.style, {
       position: "absolute",
       left: "50%",
-      top: "50%",
+      top: "45%",
       transform: "translate(-50%, -50%)",
       fontSize: "20px",
       padding: "10px 16px",
@@ -56,8 +58,11 @@ export class HomeScreen extends Phaser.Scene {
     input.focus();
     this.inputEl = input;
 
+    // Route selection UI
+    this.createRouteButtons(width / 2, height * 0.58);
+
     const playBtn = this.add
-      .text(width / 2, height * 0.62, "[ Play ]", {
+      .text(width / 2, height * 0.72, "[ Play ]", {
         fontFamily: "system-ui",
         fontSize: "32px",
         color: "#44ff88",
@@ -73,13 +78,60 @@ export class HomeScreen extends Phaser.Scene {
     });
   }
 
+  private createRouteButtons(centerX: number, y: number) {
+    const spacing = 140;
+    const routes: { id: SharkRoute; label: string; color: string }[] = [
+      { id: "attack", label: "攻撃系\n(シュモクザメ)", color: "#ff6666" },
+      { id: "non-attack", label: "非攻撃系\n(ドチザメ)", color: "#66ccff" },
+      { id: "deep-sea", label: "深海魚系\n(コビトザメ)", color: "#bb66ff" },
+    ];
+
+    const buttons: Phaser.GameObjects.Text[] = [];
+
+    routes.forEach((route, index) => {
+      const x = centerX + (index - 1) * spacing;
+      const btn = this.add.text(x, y, route.label, {
+        fontFamily: "system-ui",
+        fontSize: "14px",
+        color: "#ffffff",
+        backgroundColor: "#113355",
+        padding: { x: 10, y: 8 },
+        align: "center",
+      })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true })
+      .on("pointerdown", () => {
+        this.selectedRoute = route.id;
+        this.updateButtonStyles(buttons, routes);
+      });
+      buttons.push(btn);
+    });
+
+    this.updateButtonStyles(buttons, routes);
+  }
+
+  private updateButtonStyles(buttons: Phaser.GameObjects.Text[], routes: {id: SharkRoute, color: string}[]) {
+    buttons.forEach((btn, index) => {
+      const isSelected = this.selectedRoute === routes[index].id;
+      btn.setStyle({
+        backgroundColor: isSelected ? "#335577" : "#113355",
+        color: isSelected ? routes[index].color : "#aaaaaa",
+      });
+      if (isSelected) {
+        btn.setStroke(routes[index].color, 2);
+      } else {
+        btn.setStroke("#000000", 0);
+      }
+    });
+  }
+
   private async tryStart(): Promise<void> {
     const name = this.inputEl.value.trim() || "unknown";
     this.pendingName = name;
     try {
       if (!net.isOpen()) await net.connect();
-      net.send({ type: "join", payload: { name } });
-      this.scene.start("GameScene", { name });
+      net.send({ type: "join", payload: { name, route: this.selectedRoute } });
+      this.scene.start("GameScene", { name, route: this.selectedRoute });
     } catch (e) {
       console.error("connect failed", e);
     }

--- a/server/go.mod
+++ b/server/go.mod
@@ -2,7 +2,6 @@ module github.com/samezario/server
 
 go 1.22.2
 
-require (
-	github.com/gorilla/websocket v1.5.1 // indirect
-	golang.org/x/net v0.17.0 // indirect
-)
+require github.com/gorilla/websocket v1.5.1
+
+require golang.org/x/net v0.17.0 // indirect


### PR DESCRIPTION
#### 概要:
プレイヤーがゲーム開始時に異なる進化系統（攻撃系、非攻撃系、深海魚系）を選択できる機能を追加し、それに応じたビジュアル効果と名称の変更を実装しました。

#### 主な変更内容:
- **進化ルート選択機能**:
  - ホーム画面に「攻撃系」「非攻撃系」「深海魚系」の3つの選択肢を追加。
  - サーバーへの参加メッセージ（Join protocol）に選択したルート情報を追加。
- **ビジュアル・演出の強化**:
  - 各ルートに対応したグロー効果（外光）をサメのモデルに適用（攻撃系：赤、非攻撃系：青、深海魚系：紫）。
  - 成長段階（Stage）に応じた名称をルートごとに個別設定。
    - **攻撃系**: シュモクザメ → メガロドン
    - **非攻撃系**: ドチザメ → ジンベエザメ
    - **深海魚系**: コビトザメ → ニシオンデンザメ
- **内部ロジックの改善**:
  - 自分のID管理を強化し、選択したルートが確実に自分自身のサメに反映されるよう修正。
  - 他プレイヤーのルートが未定義の場合でも、IDから擬似的にルートを割り当てることで画面上の多様性を確保。

#### ブラウザ検証用チェックリスト:
- [ ] ホーム画面で進化ルートを選択でき、選択したボタンが強調されること。
- [ ] ゲーム開始後、自分のサメが選択したルートに応じた色のオーラを纏っていること。
- [ ] スコアを稼いでレベルアップした際、選択したルートに応じたサメの名称（例：非攻撃系なら「ジンベエザメ」）が表示されること。
- [ ] 他のサメもランダム（決定論的）に異なる色のオーラを纏っていること。


#### 補足（バックエンド未対応について）:
現在の実装では、進化ルートのサーバー連携（保存および他プレイヤーへの配信）は未対応です。フロントエンド側は送信および受信の準備が完了していますが、バックエンド側の `message.go` の対応が完了するまではクライアント側で決定論的に擬似ルートを割り当てるフォールバック機能が動作します。
