### PR TITLE
Person5: 1タスク1部屋前提のECS基盤を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ client/node_modules/
 server/samezario-server
 server/internal/static/assets/*
 !server/internal/static/assets/.gitkeep
+!server/internal/static/assets/index.html
 
 # Editor
 .vscode/

--- a/infra/README.md
+++ b/infra/README.md
@@ -10,6 +10,14 @@ Terraform for the Samether.io AWS baseline.
 - Shared state: `ElastiCache Redis`
 - GPS tracking: `Amazon Location Service Tracker`
 
+## Room Model
+
+- Each ECS task owns one independent room.
+- The ECS service keeps `2` tasks running by default.
+- ALB distributes new connections across tasks, so each task becomes a separate room.
+- A room stays local to its task memory for the PoC.
+- Redis is reserved for session, leaderboard, GPS/CP state, and future room registry use.
+
 ## Layout
 
 ```text
@@ -45,7 +53,9 @@ infra/
 
 ## Notes
 
-- The ECS service starts with `desired_count = 1`.
+- The ECS service starts with `desired_count = 2`.
+- `min_capacity = 2` keeps two rooms warm by default.
 - Auto scaling is enabled structurally, but bounded conservatively for PoC.
 - WebSocket TLS terminates at the ALB.
 - GPS/CP calculation should remain server-authoritative.
+- Each task derives its default room ID from the container hostname unless `ROOM_ID` is set explicitly.

--- a/infra/envs/dev/main.tf
+++ b/infra/envs/dev/main.tf
@@ -56,6 +56,9 @@ module "ecs_service" {
   desired_count             = var.desired_count
   min_capacity              = var.min_capacity
   max_capacity              = var.max_capacity
+  room_capacity             = var.room_capacity
+  redis_primary_endpoint    = module.redis.primary_endpoint_address
+  location_tracker_name     = module.location.tracker_name
 }
 
 module "redis" {

--- a/infra/envs/dev/terraform.tfvars.example
+++ b/infra/envs/dev/terraform.tfvars.example
@@ -4,3 +4,4 @@ route53_zone_name              = "example.com."
 acm_certificate_arn            = "arn:aws:acm:ap-northeast-1:123456789012:certificate/replace-me"
 cloudfront_acm_certificate_arn = "arn:aws:acm:us-east-1:123456789012:certificate/replace-me"
 container_image                = "123456789012.dkr.ecr.ap-northeast-1.amazonaws.com/samether-dev-server:latest"
+room_capacity                  = 50

--- a/infra/envs/dev/variables.tf
+++ b/infra/envs/dev/variables.tf
@@ -80,19 +80,25 @@ variable "ecs_memory" {
 variable "desired_count" {
   description = "Initial ECS desired count."
   type        = number
-  default     = 1
+  default     = 2
 }
 
 variable "min_capacity" {
   description = "Minimum ECS service capacity."
   type        = number
-  default     = 1
+  default     = 2
 }
 
 variable "max_capacity" {
   description = "Maximum ECS service capacity."
   type        = number
-  default     = 2
+  default     = 4
+}
+
+variable "room_capacity" {
+  description = "Maximum players allowed per task-local room."
+  type        = number
+  default     = 50
 }
 
 variable "redis_node_type" {

--- a/infra/modules/ecs_service/main.tf
+++ b/infra/modules/ecs_service/main.tf
@@ -32,6 +32,18 @@ resource "aws_ecs_task_definition" "this" {
         {
           name  = "PORT"
           value = tostring(var.container_port)
+        },
+        {
+          name  = "ROOM_CAPACITY"
+          value = tostring(var.room_capacity)
+        },
+        {
+          name  = "REDIS_ADDR"
+          value = var.redis_primary_endpoint
+        },
+        {
+          name  = "LOCATION_TRACKER_NAME"
+          value = var.location_tracker_name
         }
       ]
       logConfiguration = {

--- a/infra/modules/ecs_service/variables.tf
+++ b/infra/modules/ecs_service/variables.tf
@@ -53,3 +53,15 @@ variable "min_capacity" {
 variable "max_capacity" {
   type = number
 }
+
+variable "room_capacity" {
+  type = number
+}
+
+variable "redis_primary_endpoint" {
+  type = string
+}
+
+variable "location_tracker_name" {
+  type = string
+}

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -4,28 +4,70 @@ import (
 	"flag"
 	"log"
 	"net/http"
+	"os"
+	"strconv"
 
-	sws "github.com/samezario/server/internal/ws"
 	sstatic "github.com/samezario/server/internal/static"
+	sws "github.com/samezario/server/internal/ws"
 )
 
 func main() {
 	addr := flag.String("addr", ":8080", "HTTP listen address")
 	flag.Parse()
 
-	hub := sws.NewHub()
+	roomCapacity := 50
+	if raw := os.Getenv("ROOM_CAPACITY"); raw != "" {
+		if parsed, err := strconv.Atoi(raw); err == nil && parsed > 0 {
+			roomCapacity = parsed
+		}
+	}
+
+	defaultRoomID := defaultRoomID()
+	roomID := getenvDefault("ROOM_ID", defaultRoomID)
+	instanceID := getenvDefault("INSTANCE_ID", roomID)
+
+	hub := sws.NewHub(sws.Config{
+		RoomID:       roomID,
+		RoomCapacity: roomCapacity,
+		InstanceID:   instanceID,
+	})
 	go hub.Run()
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))
+	})
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok","roomId":"` + roomID + `","instanceId":"` + instanceID + `"}`))
+	})
+	mux.HandleFunc("/room", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(sws.MustMarshal("room", hub.RoomSnapshot()))
 	})
 	mux.HandleFunc("/ws", hub.ServeWS)
 	mux.Handle("/", http.FileServer(http.FS(sstatic.FS())))
 
-	log.Printf("samezario-server listening on %s", *addr)
+	log.Printf("samezario-server listening on %s room_id=%s capacity=%d instance_id=%s", *addr, roomID, roomCapacity, instanceID)
 	if err := http.ListenAndServe(*addr, mux); err != nil {
 		log.Fatal(err)
 	}
+}
+
+func getenvDefault(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}
+
+func defaultRoomID() string {
+	hostname, err := os.Hostname()
+	if err == nil && hostname != "" {
+		return hostname
+	}
+	return "room-1"
 }

--- a/server/internal/game/leaderboard.go
+++ b/server/internal/game/leaderboard.go
@@ -47,3 +47,16 @@ func (l *Leaderboard) EndTick() bool {
 func (l *Leaderboard) Top() (name string, score int, ok bool) {
 	return l.lastTopName, l.lastTopScore, l.lastHasData
 }
+
+// Update keeps older tests and callers working in single-step mode.
+func (l *Leaderboard) Update(name string, score int) bool {
+	if !l.lastHasData || score > l.lastTopScore || name == l.lastTopName {
+		changed := !l.lastHasData || l.lastTopName != name || l.lastTopScore != score
+		l.lastTopID = name
+		l.lastTopName = name
+		l.lastTopScore = score
+		l.lastHasData = true
+		return changed
+	}
+	return false
+}

--- a/server/internal/static/assets/index.html
+++ b/server/internal/static/assets/index.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Samether.io</title>
+  </head>
+  <body>
+    <p>client assets are bundled during the Docker build</p>
+  </body>
+</html>

--- a/server/internal/ws/hub.go
+++ b/server/internal/ws/hub.go
@@ -19,6 +19,10 @@ type inboundMsg struct {
 }
 
 type Hub struct {
+	roomID       string
+	roomCapacity int
+	instanceID   string
+
 	world       *game.World
 	leaderboard *game.Leaderboard
 	clients     map[*Client]bool
@@ -31,17 +35,36 @@ type Hub struct {
 	nextBotID    uint64
 }
 
-func NewHub() *Hub {
+type Config struct {
+	RoomID       string
+	RoomCapacity int
+	InstanceID   string
+}
+
+func NewHub(cfg Config) *Hub {
 	w := game.NewWorld()
 	w.SpawnFoodsTo(game.FoodCount)
 
+	if cfg.RoomID == "" {
+		cfg.RoomID = "room-1"
+	}
+	if cfg.RoomCapacity <= 0 {
+		cfg.RoomCapacity = 50
+	}
+	if cfg.InstanceID == "" {
+		cfg.InstanceID = cfg.RoomID
+	}
+
 	return &Hub{
-		world:       w,
-		leaderboard: game.NewLeaderboard(),
-		clients:     make(map[*Client]bool),
-		register:    make(chan *Client),
-		unregister:  make(chan *Client, 16),
-		inbound:     make(chan inboundMsg, 256),
+		roomID:       cfg.RoomID,
+		roomCapacity: cfg.RoomCapacity,
+		instanceID:   cfg.InstanceID,
+		world:        w,
+		leaderboard:  game.NewLeaderboard(),
+		clients:      make(map[*Client]bool),
+		register:     make(chan *Client),
+		unregister:   make(chan *Client, 16),
+		inbound:      make(chan inboundMsg, 256),
 	}
 }
 
@@ -59,17 +82,36 @@ func (h *Hub) ServeWS(w http.ResponseWriter, r *http.Request) {
 	}
 
 	client := &Client{
-		hub:  h,
-		conn: conn,
-		send: make(chan []byte, 64),
+		hub:        h,
+		conn:       conn,
+		send:       make(chan []byte, 64),
 		lastSharks: make(map[string]StateSharkView),
-		lastFoods: make(map[string]StateFoodView),
+		lastFoods:  make(map[string]StateFoodView),
 	}
 
 	h.register <- client
 
 	go client.writePump()
 	go client.readPump()
+}
+
+func (h *Hub) RoomSnapshot() RoomInfoPayload {
+	return RoomInfoPayload{
+		ID:         h.roomID,
+		Capacity:   h.roomCapacity,
+		Players:    h.playerCount(),
+		InstanceID: h.instanceID,
+	}
+}
+
+func (h *Hub) playerCount() int {
+	count := 0
+	for _, shark := range h.world.Sharks {
+		if shark != nil && shark.Alive && !shark.IsBot {
+			count++
+		}
+	}
+	return count
 }
 
 func (h *Hub) allocPlayerID() string {
@@ -157,6 +199,17 @@ func (h *Hub) handleInbound(m inboundMsg) {
 	switch typ {
 
 	case "join":
+		if m.client.playerID != "" {
+			return
+		}
+		if h.playerCount() >= h.roomCapacity {
+			h.send(m.client, "room_full", RoomFullPayload{
+				Room:   h.RoomSnapshot(),
+				Reason: "room capacity reached",
+			})
+			return
+		}
+
 		p := payload.(JoinPayload)
 
 		id := h.allocPlayerID()
@@ -169,6 +222,7 @@ func (h *Hub) handleInbound(m inboundMsg) {
 			PlayerID: id,
 			WorldW:   game.WorldWidth,
 			WorldH:   game.WorldHeight,
+			Room:     h.RoomSnapshot(),
 		})
 
 		name, score, ok := h.leaderboard.Top()
@@ -294,9 +348,9 @@ func (h *Hub) sendStateTo(c *Client) {
 
 	if self == nil {
 		payload := StatePayload{
-			Tick: h.world.Tick,
-			Full: true,
-			You:  StateYou{},
+			Tick:   h.world.Tick,
+			Full:   true,
+			You:    StateYou{},
 			Sharks: []StateSharkView{},
 			Foods:  []StateFoodView{},
 		}

--- a/server/internal/ws/message.go
+++ b/server/internal/ws/message.go
@@ -38,26 +38,27 @@ type InputPayload struct {
 // ============================================================
 
 type WelcomePayload struct {
-	PlayerID string  `json:"playerId"`
-	WorldW   float64 `json:"worldW"`
-	WorldH   float64 `json:"worldH"`
+	PlayerID string          `json:"playerId"`
+	WorldW   float64         `json:"worldW"`
+	WorldH   float64         `json:"worldH"`
+	Room     RoomInfoPayload `json:"room"`
 }
 
 type StatePayload struct {
-	Tick int64 `json:"tick"`
-	You StateYou `json:"you"`
-	Full bool `json:"full,omitempty"`
+	Tick int64    `json:"tick"`
+	You  StateYou `json:"you"`
+	Full bool     `json:"full,omitempty"`
 
 	Sharks []StateSharkView `json:"sharks,omitempty"`
-	Foods []StateFoodView `json:"foods,omitempty"`
+	Foods  []StateFoodView  `json:"foods,omitempty"`
 
-	AddedSharks []StateSharkView `json:"addedSharks,omitempty"`
+	AddedSharks   []StateSharkView `json:"addedSharks,omitempty"`
 	UpdatedSharks []StateSharkView `json:"updatedSharks,omitempty"`
-	RemovedSharks []string `json:"removedSharks,omitempty"`
+	RemovedSharks []string         `json:"removedSharks,omitempty"`
 
-	AddedFoods []StateFoodView `json:"addedFoods,omitempty"`
+	AddedFoods   []StateFoodView `json:"addedFoods,omitempty"`
 	UpdatedFoods []StateFoodView `json:"updatedFoods,omitempty"`
-	RemovedFoods []string `json:"removedFoods,omitempty"`
+	RemovedFoods []string        `json:"removedFoods,omitempty"`
 }
 
 type DeathPayload struct {
@@ -68,6 +69,18 @@ type DeathPayload struct {
 type LeaderboardPayload struct {
 	TopName  string `json:"topName"`
 	TopScore int    `json:"topScore"`
+}
+
+type RoomInfoPayload struct {
+	ID         string `json:"id"`
+	Capacity   int    `json:"capacity"`
+	Players    int    `json:"players"`
+	InstanceID string `json:"instanceId"`
+}
+
+type RoomFullPayload struct {
+	Room   RoomInfoPayload `json:"room"`
+	Reason string          `json:"reason"`
 }
 
 // ============================================================


### PR DESCRIPTION
## 概要
- ECS on Fargate を 1タスク=1部屋 の前提で運用できるように整理
- ECS Service を常時2タスクで起動する Terraform 設定に変更
- サーバーに room 情報と room capacity の最小設定を追加

## 変更内容
- Terraform の ECS 設定を `desired_count=2`, `min_capacity=2`, `max_capacity=4` に変更
- ECS タスクへ `ROOM_CAPACITY`, `REDIS_ADDR`, `LOCATION_TRACKER_NAME` を注入
- `welcome` に room 情報を追加し、`/room` と `room_full` を追加
- `/health` と `/healthz` で room / instance 情報を返すように変更
- infra / README を現方針に合わせて更新

## 補足
- PoC 段階では各タスクが独立した部屋を持つ想定です
- 共有ワールドは今後必要になった時点で再検討します

## 確認
- `go test ./...` は通過
- `terraform validate` はこの環境では provider 実行制約があり未確認