### PR TITLE
Person 3: Route フィールドのサーバー対応

### DIFF
--- a/server/internal/game/shark.go
+++ b/server/internal/game/shark.go
@@ -2,9 +2,28 @@ package game
 
 import "math"
 
+// Route identifiers shared with the client (see client/src/network/protocol.ts).
+const (
+	RouteAttack    = "attack"
+	RouteNonAttack = "non-attack"
+	RouteDeepSea   = "deep-sea"
+)
+
+// NormalizeRoute returns a valid route, falling back to RouteAttack for
+// unknown or empty inputs.
+func NormalizeRoute(r string) string {
+	switch r {
+	case RouteAttack, RouteNonAttack, RouteDeepSea:
+		return r
+	default:
+		return RouteAttack
+	}
+}
+
 type Shark struct {
 	ID            string
 	Name          string
+	Route         string
 	Head          Vec
 	Angle         float64 // radians
 	TargetAngle   float64 // target turning angle
@@ -23,6 +42,7 @@ func NewShark(id, name string, spawn Vec) *Shark {
 	s := &Shark{
 		ID:          id,
 		Name:        name,
+		Route:       RouteAttack,
 		Head:        spawn,
 		Angle:       0,
 		TargetAngle: 0,

--- a/server/internal/ws/hub.go
+++ b/server/internal/ws/hub.go
@@ -108,6 +108,11 @@ func randomSpawn() game.Vec {
 	}
 }
 
+func randomBotRoute() string {
+	routes := []string{game.RouteAttack, game.RouteNonAttack, game.RouteDeepSea}
+	return routes[rand.Intn(len(routes))]
+}
+
 // 新送信関数（Payload対応）
 func (h *Hub) send(c *Client, typ string, payload any) {
 	b := MustMarshal(typ, payload)
@@ -163,6 +168,7 @@ func (h *Hub) handleInbound(m inboundMsg) {
 		m.client.playerID = id
 
 		s := game.NewShark(id, p.Name, randomSpawn())
+		s.Route = game.NormalizeRoute(p.Route)
 		h.world.Sharks[id] = s
 
 		h.send(m.client, "welcome", WelcomePayload{
@@ -205,6 +211,7 @@ func (h *Hub) step(dt float64) {
 
 		s := game.NewShark(id, name, randomSpawn())
 		s.IsBot = true
+		s.Route = randomBotRoute()
 		h.world.Sharks[id] = s
 	}
 
@@ -282,7 +289,7 @@ func (h *Hub) broadcastLeaderboard() {
 }
 
 func sharkViewEqual(a, b StateSharkView) bool {
-	return a.ID == b.ID && a.Name == b.Name && a.X == b.X && a.Y == b.Y && a.Angle == b.Angle && a.Stage == b.Stage
+	return a.ID == b.ID && a.Name == b.Name && a.X == b.X && a.Y == b.Y && a.Angle == b.Angle && a.Stage == b.Stage && a.Route == b.Route
 }
 
 func foodViewEqual(a, b StateFoodView) bool {
@@ -325,6 +332,7 @@ func (h *Hub) sendStateTo(c *Client) {
 			Y:     s.Head.Y,
 			Angle: s.Angle,
 			Stage: s.Stage,
+			Route: s.Route,
 		}
 		currentSharks = append(currentSharks, view)
 		currentSharkMap[view.ID] = view

--- a/server/internal/ws/message.go
+++ b/server/internal/ws/message.go
@@ -25,7 +25,8 @@ type Point struct {
 // ============================================================
 
 type JoinPayload struct {
-	Name string `json:"name"`
+	Name  string `json:"name"`
+	Route string `json:"route,omitempty"`
 }
 
 type InputPayload struct {
@@ -81,6 +82,7 @@ type StateSharkView struct {
 	Y     float64 `json:"y"`
 	Angle float64 `json:"angle"`
 	Stage int     `json:"stage"`
+	Route string  `json:"route,omitempty"`
 }
 
 type StateFoodView struct {


### PR DESCRIPTION
## Summary
PR #11（Person 1）のクライアント先行実装に対応する **サーバー側の最小実装**。
プレイヤーが `join` 時に選んだ進化ルート（`attack` / `non-attack` / `deep-sea`）をサーバーが受け取って保持し、`state` メッセージで他クライアントへ配信します。

## 変更内容

### `server/internal/game/shark.go`
- `Shark` 構造体に `Route string` フィールド追加
- `RouteAttack` / `RouteNonAttack` / `RouteDeepSea` 定数を追加（クライアントと文字列一致）
- `NormalizeRoute(r string) string` — 未知の値は `attack` にフォールバック

### `server/internal/ws/message.go`
- `JoinPayload` に `Route string` を追加（`omitempty`）
- `StateSharkView` に `Route string` を追加（`omitempty`）

### `server/internal/ws/hub.go`
- `join` ハンドラで `NormalizeRoute(p.Route)` を適用してサメに設定
- `sendStateTo` で `StateSharkView.Route` を populate
- ボット生成時にランダムルートを割り当てる `randomBotRoute()` を追加（見た目の多様性のため）
- `sharkViewEqual` が `Route` の差分も検出するよう拡張

## Test plan
`docker compose build && docker compose up -d` の上で WebSocket クライアントから `join` を送信して検証。

| 入力 route | 結果 |
|---|---|
| `"attack"` | そのまま保持 ✓ |
| `"non-attack"` | そのまま保持 ✓ |
| `"deep-sea"` | そのまま保持 ✓ |
| `""` | `"attack"` にフォールバック ✓ |
| `"garbage"` | `"attack"` にフォールバック ✓ |
| ボット | `attack` / `non-attack` / `deep-sea` が混在 ✓ |

## 残項目（別 PR 想定）
- ルート別の `Stages` 差別化（速度・燃費・体節数）— 仕様書 §5.2-5.4 の本格実装
- CP システム（Phase 2 / Person 5 と協調）
- メガロドンの血の知覚・ニシオンデンザメの自動成長などルート固有能力

## マージ順序の注意
- **本 PR は #11 とセットでマージされることで意味を持ちます**。先に本 PR を main に入れてから #11 をマージすれば、クライアントは自然にサーバーの `route` を受け取れるようになります
- #11 先マージでも問題なし（クライアントのフォールバック `getDummyRoute` が働く）

Refs: #11