### PR TITLE
feat(client): CP 獲得画面を追加 (GPS 計測ベース)

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,5 +1,6 @@
 import Phaser from "phaser";
 import { HomeScreen } from "./ui/screens/HomeScreen";
+import { CPScreen } from "./ui/screens/CPScreen";
 import { GameScene } from "./game/scenes/GameScene";
 import { DeathScreen } from "./ui/screens/DeathScreen";
 
@@ -12,7 +13,7 @@ const config: Phaser.Types.Core.GameConfig = {
     width: "100%",
     height: "100%",
   },
-  scene: [HomeScreen, GameScene, DeathScreen],
+  scene: [HomeScreen, CPScreen, GameScene, DeathScreen],
 };
 
 new Phaser.Game(config);

--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -1,4 +1,5 @@
 import Phaser from "phaser";
+import { LoginScreen } from "./ui/screens/LoginScreen";
 import { HomeScreen } from "./ui/screens/HomeScreen";
 import { CPScreen } from "./ui/screens/CPScreen";
 import { GameScene } from "./game/scenes/GameScene";
@@ -13,7 +14,7 @@ const config: Phaser.Types.Core.GameConfig = {
     width: "100%",
     height: "100%",
   },
-  scene: [HomeScreen, CPScreen, GameScene, DeathScreen],
+  scene: [LoginScreen, HomeScreen, CPScreen, GameScene, DeathScreen],
 };
 
 new Phaser.Game(config);

--- a/client/src/storage/auth.ts
+++ b/client/src/storage/auth.ts
@@ -1,0 +1,79 @@
+const USERS_KEY = "samether_users";
+const SESSION_KEY = "samether_session";
+
+interface UserRecord {
+  name: string;
+  passwordHash: string;
+}
+
+async function hashPassword(password: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(password);
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function loadUsers(): UserRecord[] {
+  const raw = localStorage.getItem(USERS_KEY);
+  if (!raw) return [];
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return [];
+  }
+}
+
+function saveUsers(users: UserRecord[]): void {
+  localStorage.setItem(USERS_KEY, JSON.stringify(users));
+}
+
+export async function register(
+  name: string,
+  password: string,
+): Promise<{ ok: boolean; error?: string }> {
+  if (!name || !password) {
+    return { ok: false, error: "名前とパスワードを入力してください" };
+  }
+  const users = loadUsers();
+  if (users.some((u) => u.name === name)) {
+    return { ok: false, error: "この名前は既に使用されています" };
+  }
+  const passwordHash = await hashPassword(password);
+  users.push({ name, passwordHash });
+  saveUsers(users);
+  setSession(name);
+  return { ok: true };
+}
+
+export async function login(
+  name: string,
+  password: string,
+): Promise<{ ok: boolean; error?: string }> {
+  if (!name || !password) {
+    return { ok: false, error: "名前とパスワードを入力してください" };
+  }
+  const users = loadUsers();
+  const user = users.find((u) => u.name === name);
+  if (!user) {
+    return { ok: false, error: "ユーザーが見つかりません" };
+  }
+  const passwordHash = await hashPassword(password);
+  if (user.passwordHash !== passwordHash) {
+    return { ok: false, error: "パスワードが正しくありません" };
+  }
+  setSession(name);
+  return { ok: true };
+}
+
+export function getSession(): string | null {
+  return localStorage.getItem(SESSION_KEY);
+}
+
+function setSession(name: string): void {
+  localStorage.setItem(SESSION_KEY, name);
+}
+
+export function logout(): void {
+  localStorage.removeItem(SESSION_KEY);
+}

--- a/client/src/storage/cp.ts
+++ b/client/src/storage/cp.ts
@@ -1,0 +1,18 @@
+const STORAGE_KEY = "samether_cp";
+
+export function loadCp(): number {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (raw == null) return 0;
+  const n = parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 0 ? n : 0;
+}
+
+export function addCp(earned: number): number {
+  const next = Math.max(0, loadCp() + Math.max(0, Math.floor(earned)));
+  localStorage.setItem(STORAGE_KEY, String(next));
+  return next;
+}
+
+export function resetCp(): void {
+  localStorage.removeItem(STORAGE_KEY);
+}

--- a/client/src/ui/screens/CPScreen.ts
+++ b/client/src/ui/screens/CPScreen.ts
@@ -1,0 +1,204 @@
+import Phaser from "phaser";
+import { addCp, loadCp } from "../../storage/cp";
+
+const METERS_PER_CP = 50;
+const MAX_EARN_PER_SESSION = 100;
+const GEO_TIMEOUT_MS = 10000;
+
+type Phase = "idle" | "measuring" | "finalizing" | "done";
+
+export class CPScreen extends Phaser.Scene {
+  private cpDisplayText!: Phaser.GameObjects.Text;
+  private statusText!: Phaser.GameObjects.Text;
+  private startBtn!: Phaser.GameObjects.Text;
+  private goalBtn!: Phaser.GameObjects.Text;
+
+  private startCoords: { lat: number; lon: number } | null = null;
+  private phase: Phase = "idle";
+
+  constructor() {
+    super({ key: "CPScreen" });
+  }
+
+  create(): void {
+    const { width, height } = this.scale;
+    this.cameras.main.setBackgroundColor("#001b44");
+
+    this.add
+      .text(width / 2, height * 0.15, "CP 獲得", {
+        fontFamily: "system-ui",
+        fontSize: "48px",
+        color: "#88ccee",
+      })
+      .setOrigin(0.5);
+
+    this.cpDisplayText = this.add
+      .text(width / 2, height * 0.27, `所持 CP: ${loadCp()}`, {
+        fontFamily: "system-ui",
+        fontSize: "24px",
+        color: "#ddeeff",
+      })
+      .setOrigin(0.5);
+
+    this.add
+      .text(
+        width / 2,
+        height * 0.37,
+        `スタート地点で [ スタート ]、目的地で [ ゴール ] を押してください\n移動距離 ${METERS_PER_CP} m につき 1 CP (1 回最大 ${MAX_EARN_PER_SESSION} CP)`,
+        {
+          fontFamily: "system-ui",
+          fontSize: "15px",
+          color: "#6688aa",
+          align: "center",
+        },
+      )
+      .setOrigin(0.5);
+
+    this.statusText = this.add
+      .text(width / 2, height * 0.5, "待機中", {
+        fontFamily: "system-ui",
+        fontSize: "22px",
+        color: "#aaaaaa",
+      })
+      .setOrigin(0.5);
+
+    this.startBtn = this.add
+      .text(width / 2, height * 0.62, "[ スタート ]", {
+        fontFamily: "system-ui",
+        fontSize: "32px",
+        color: "#44ff88",
+      })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true })
+      .on("pointerdown", () => this.handleStart());
+
+    this.goalBtn = this.add
+      .text(width / 2, height * 0.73, "[ ゴール ]", {
+        fontFamily: "system-ui",
+        fontSize: "32px",
+        color: "#555555",
+      })
+      .setOrigin(0.5)
+      .on("pointerdown", () => this.handleGoal());
+
+    this.add
+      .text(width / 2, height * 0.87, "[ ホームへ戻る ]", {
+        fontFamily: "system-ui",
+        fontSize: "22px",
+        color: "#6688aa",
+      })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true })
+      .on("pointerdown", () => this.scene.start("HomeScreen"));
+
+    this.applyPhase();
+  }
+
+  private handleStart(): void {
+    if (this.phase !== "idle") return;
+    if (!navigator.geolocation) {
+      this.setStatus("位置情報が利用できません", "#ff6666");
+      return;
+    }
+
+    this.phase = "measuring";
+    this.applyPhase();
+    this.setStatus("現在地を取得中...", "#ffdd44");
+
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        this.startCoords = { lat: pos.coords.latitude, lon: pos.coords.longitude };
+        this.setStatus("計測中... 目的地へ移動して [ ゴール ] を押してください", "#44ff88");
+      },
+      (err) => {
+        this.phase = "idle";
+        this.applyPhase();
+        this.setStatus(`位置情報エラー: ${err.message}`, "#ff6666");
+      },
+      { enableHighAccuracy: true, timeout: GEO_TIMEOUT_MS },
+    );
+  }
+
+  private handleGoal(): void {
+    if (this.phase !== "measuring" || !this.startCoords) return;
+
+    this.phase = "finalizing";
+    this.applyPhase();
+    this.setStatus("終了地点を取得中...", "#ffdd44");
+
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        const dist = this.haversineMeters(
+          this.startCoords!.lat,
+          this.startCoords!.lon,
+          pos.coords.latitude,
+          pos.coords.longitude,
+        );
+        const earned = Math.min(
+          Math.floor(dist / METERS_PER_CP),
+          MAX_EARN_PER_SESSION,
+        );
+        const newTotal = earned > 0 ? addCp(earned) : loadCp();
+        this.cpDisplayText.setText(`所持 CP: ${newTotal}`);
+        this.setStatus(
+          `距離: ${Math.round(dist)} m  /  +${earned} CP\n合計 ${newTotal} CP`,
+          "#44ff88",
+        );
+        this.startCoords = null;
+        this.phase = "done";
+        this.applyPhase();
+      },
+      (err) => {
+        this.phase = "measuring";
+        this.applyPhase();
+        this.setStatus(`位置情報エラー: ${err.message}`, "#ff6666");
+      },
+      { enableHighAccuracy: true, timeout: GEO_TIMEOUT_MS },
+    );
+  }
+
+  /** UI state derived from phase. Buttons' enable/disable live here only. */
+  private applyPhase(): void {
+    const setEnabled = (btn: Phaser.GameObjects.Text, enabled: boolean, activeColor: string) => {
+      if (enabled) {
+        btn.setInteractive({ useHandCursor: true }).setColor(activeColor);
+      } else {
+        btn.disableInteractive().setColor("#555555");
+      }
+    };
+
+    switch (this.phase) {
+      case "idle":
+        setEnabled(this.startBtn, true, "#44ff88");
+        setEnabled(this.goalBtn, false, "#ffaa44");
+        break;
+      case "measuring":
+        setEnabled(this.startBtn, false, "#44ff88");
+        setEnabled(this.goalBtn, true, "#ffaa44");
+        break;
+      case "finalizing":
+        setEnabled(this.startBtn, false, "#44ff88");
+        setEnabled(this.goalBtn, false, "#ffaa44");
+        break;
+      case "done":
+        setEnabled(this.startBtn, true, "#44ff88");
+        setEnabled(this.goalBtn, false, "#ffaa44");
+        break;
+    }
+  }
+
+  private setStatus(msg: string, color: string): void {
+    this.statusText.setText(msg).setColor(color);
+  }
+
+  private haversineMeters(lat1: number, lon1: number, lat2: number, lon2: number): number {
+    const R = 6371000;
+    const toRad = (d: number) => (d * Math.PI) / 180;
+    const dLat = toRad(lat2 - lat1);
+    const dLon = toRad(lon2 - lon1);
+    const a =
+      Math.sin(dLat / 2) ** 2 +
+      Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+    return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  }
+}

--- a/client/src/ui/screens/HomeScreen.ts
+++ b/client/src/ui/screens/HomeScreen.ts
@@ -2,22 +2,29 @@ import Phaser from "phaser";
 import { net } from "../../network/websocket";
 import { SharkRoute } from "../../network/protocol";
 import { loadCp } from "../../storage/cp";
+import { getSession, logout } from "../../storage/auth";
 
 export class HomeScreen extends Phaser.Scene {
-  private inputEl!: HTMLInputElement;
-  private pendingName = "";
-  private selectedRoute: SharkRoute = "attack"; // Default route
+  private playerName = "";
+  private selectedRoute: SharkRoute = "attack";
 
   constructor() {
     super({ key: "HomeScreen" });
   }
 
   create(): void {
+    const session = getSession();
+    if (!session) {
+      this.scene.start("LoginScreen");
+      return;
+    }
+    this.playerName = session;
+
     const { width, height } = this.scale;
     this.cameras.main.setBackgroundColor("#001b44");
 
     this.add
-      .text(width / 2, height * 0.18, "サメザリオ", {
+      .text(width / 2, height * 0.12, "サメザリオ", {
         fontFamily: "system-ui",
         fontSize: "56px",
         color: "#88ccee",
@@ -25,45 +32,17 @@ export class HomeScreen extends Phaser.Scene {
       .setOrigin(0.5);
 
     this.add
-      .text(width / 2, height * 0.28, "Slither.io-style shark PoC", {
+      .text(width / 2, height * 0.22, `ようこそ、${this.playerName}`, {
         fontFamily: "system-ui",
-        fontSize: "18px",
-        color: "#6688aa",
+        fontSize: "22px",
+        color: "#ddeeff",
       })
       .setOrigin(0.5);
 
-    // Name input: overlay a real HTML input.
-    const existing = document.getElementById("name-input") as HTMLInputElement | null;
-    if (existing) existing.remove();
-    const input = document.createElement("input");
-    input.id = "name-input";
-    input.type = "text";
-    input.placeholder = "名前を入力";
-    input.maxLength = 16;
-    Object.assign(input.style, {
-      position: "absolute",
-      left: "50%",
-      top: "38%",
-      transform: "translate(-50%, -50%)",
-      fontSize: "20px",
-      padding: "10px 16px",
-      borderRadius: "6px",
-      border: "1px solid #446688",
-      background: "#002b5c",
-      color: "#ddeeff",
-      outline: "none",
-      width: "240px",
-      textAlign: "center",
-    } as CSSStyleDeclaration);
-    document.body.appendChild(input);
-    input.focus();
-    this.inputEl = input;
-
-    // Route selection UI
-    this.createRouteButtons(width / 2, height * 0.5);
+    this.createRouteButtons(width / 2, height * 0.37);
 
     this.add
-      .text(width / 2, height * 0.63, "[ Play ]", {
+      .text(width / 2, height * 0.52, "[ Play ]", {
         fontFamily: "system-ui",
         fontSize: "32px",
         color: "#44ff88",
@@ -72,10 +51,8 @@ export class HomeScreen extends Phaser.Scene {
       .setInteractive({ useHandCursor: true })
       .on("pointerdown", () => this.tryStart());
 
-    this.input.keyboard?.on("keydown-ENTER", () => this.tryStart());
-
     this.add
-      .text(width / 2, height * 0.75, "[ CP 獲得 ]", {
+      .text(width / 2, height * 0.64, "[ CP 獲得 ]", {
         fontFamily: "system-ui",
         fontSize: "22px",
         color: "#ffaa44",
@@ -85,16 +62,25 @@ export class HomeScreen extends Phaser.Scene {
       .on("pointerdown", () => this.scene.start("CPScreen"));
 
     this.add
-      .text(width / 2, height * 0.84, `所持 CP: ${loadCp()}`, {
+      .text(width / 2, height * 0.73, `所持 CP: ${loadCp()}`, {
         fontFamily: "system-ui",
         fontSize: "18px",
         color: "#6688aa",
       })
       .setOrigin(0.5);
 
-    this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
-      input.remove();
-    });
+    this.add
+      .text(width / 2, height * 0.85, "[ ログアウト ]", {
+        fontFamily: "system-ui",
+        fontSize: "18px",
+        color: "#ff6666",
+      })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true })
+      .on("pointerdown", () => {
+        logout();
+        this.scene.start("LoginScreen");
+      });
   }
 
   private createRouteButtons(centerX: number, y: number) {
@@ -147,12 +133,10 @@ export class HomeScreen extends Phaser.Scene {
   }
 
   private async tryStart(): Promise<void> {
-    const name = this.inputEl.value.trim() || "unknown";
-    this.pendingName = name;
     try {
       if (!net.isOpen()) await net.connect();
-      net.send({ type: "join", payload: { name, route: this.selectedRoute } });
-      this.scene.start("GameScene", { name, route: this.selectedRoute });
+      net.send({ type: "join", payload: { name: this.playerName, route: this.selectedRoute } });
+      this.scene.start("GameScene", { name: this.playerName, route: this.selectedRoute });
     } catch (e) {
       console.error("connect failed", e);
     }

--- a/client/src/ui/screens/HomeScreen.ts
+++ b/client/src/ui/screens/HomeScreen.ts
@@ -1,6 +1,7 @@
 import Phaser from "phaser";
 import { net } from "../../network/websocket";
 import { SharkRoute } from "../../network/protocol";
+import { loadCp } from "../../storage/cp";
 
 export class HomeScreen extends Phaser.Scene {
   private inputEl!: HTMLInputElement;
@@ -16,7 +17,7 @@ export class HomeScreen extends Phaser.Scene {
     this.cameras.main.setBackgroundColor("#001b44");
 
     this.add
-      .text(width / 2, height * 0.25, "サメザリオ", {
+      .text(width / 2, height * 0.18, "サメザリオ", {
         fontFamily: "system-ui",
         fontSize: "56px",
         color: "#88ccee",
@@ -24,7 +25,7 @@ export class HomeScreen extends Phaser.Scene {
       .setOrigin(0.5);
 
     this.add
-      .text(width / 2, height * 0.35, "Slither.io-style shark PoC", {
+      .text(width / 2, height * 0.28, "Slither.io-style shark PoC", {
         fontFamily: "system-ui",
         fontSize: "18px",
         color: "#6688aa",
@@ -42,7 +43,7 @@ export class HomeScreen extends Phaser.Scene {
     Object.assign(input.style, {
       position: "absolute",
       left: "50%",
-      top: "45%",
+      top: "38%",
       transform: "translate(-50%, -50%)",
       fontSize: "20px",
       padding: "10px 16px",
@@ -59,10 +60,10 @@ export class HomeScreen extends Phaser.Scene {
     this.inputEl = input;
 
     // Route selection UI
-    this.createRouteButtons(width / 2, height * 0.58);
+    this.createRouteButtons(width / 2, height * 0.5);
 
-    const playBtn = this.add
-      .text(width / 2, height * 0.72, "[ Play ]", {
+    this.add
+      .text(width / 2, height * 0.63, "[ Play ]", {
         fontFamily: "system-ui",
         fontSize: "32px",
         color: "#44ff88",
@@ -72,6 +73,24 @@ export class HomeScreen extends Phaser.Scene {
       .on("pointerdown", () => this.tryStart());
 
     this.input.keyboard?.on("keydown-ENTER", () => this.tryStart());
+
+    this.add
+      .text(width / 2, height * 0.75, "[ CP 獲得 ]", {
+        fontFamily: "system-ui",
+        fontSize: "22px",
+        color: "#ffaa44",
+      })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true })
+      .on("pointerdown", () => this.scene.start("CPScreen"));
+
+    this.add
+      .text(width / 2, height * 0.84, `所持 CP: ${loadCp()}`, {
+        fontFamily: "system-ui",
+        fontSize: "18px",
+        color: "#6688aa",
+      })
+      .setOrigin(0.5);
 
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
       input.remove();

--- a/client/src/ui/screens/LoginScreen.ts
+++ b/client/src/ui/screens/LoginScreen.ts
@@ -1,0 +1,138 @@
+import Phaser from "phaser";
+import { login, register, getSession } from "../../storage/auth";
+
+export class LoginScreen extends Phaser.Scene {
+  private nameInput!: HTMLInputElement;
+  private passwordInput!: HTMLInputElement;
+  private errorText!: Phaser.GameObjects.Text;
+
+  constructor() {
+    super({ key: "LoginScreen" });
+  }
+
+  create(): void {
+    const session = getSession();
+    if (session) {
+      this.scene.start("HomeScreen");
+      return;
+    }
+
+    const { width, height } = this.scale;
+    this.cameras.main.setBackgroundColor("#001b44");
+
+    this.add
+      .text(width / 2, height * 0.12, "サメザリオ", {
+        fontFamily: "system-ui",
+        fontSize: "56px",
+        color: "#88ccee",
+      })
+      .setOrigin(0.5);
+
+    this.add
+      .text(width / 2, height * 0.23, "ログイン", {
+        fontFamily: "system-ui",
+        fontSize: "28px",
+        color: "#ddeeff",
+      })
+      .setOrigin(0.5);
+
+    this.nameInput = this.createInput("login-name", "名前を入力", "35%", 16);
+    this.passwordInput = this.createInput("login-password", "パスワード", "45%", 32, true);
+
+    this.errorText = this.add
+      .text(width / 2, height * 0.53, "", {
+        fontFamily: "system-ui",
+        fontSize: "16px",
+        color: "#ff6666",
+        align: "center",
+      })
+      .setOrigin(0.5);
+
+    this.add
+      .text(width / 2, height * 0.62, "[ ログイン ]", {
+        fontFamily: "system-ui",
+        fontSize: "32px",
+        color: "#44ff88",
+      })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true })
+      .on("pointerdown", () => this.handleLogin());
+
+    this.add
+      .text(width / 2, height * 0.73, "[ 新規登録 ]", {
+        fontFamily: "system-ui",
+        fontSize: "28px",
+        color: "#ffaa44",
+      })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true })
+      .on("pointerdown", () => this.handleRegister());
+
+    this.nameInput.focus();
+
+    this.passwordInput.addEventListener("keydown", (e) => {
+      if (e.key === "Enter") this.handleLogin();
+    });
+
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
+      this.nameInput.remove();
+      this.passwordInput.remove();
+    });
+  }
+
+  private createInput(
+    id: string,
+    placeholder: string,
+    top: string,
+    maxLength: number,
+    isPassword = false,
+  ): HTMLInputElement {
+    const existing = document.getElementById(id) as HTMLInputElement | null;
+    if (existing) existing.remove();
+
+    const input = document.createElement("input");
+    input.id = id;
+    input.type = isPassword ? "password" : "text";
+    input.placeholder = placeholder;
+    input.maxLength = maxLength;
+    Object.assign(input.style, {
+      position: "absolute",
+      left: "50%",
+      top,
+      transform: "translate(-50%, -50%)",
+      fontSize: "20px",
+      padding: "10px 16px",
+      borderRadius: "6px",
+      border: "1px solid #446688",
+      background: "#002b5c",
+      color: "#ddeeff",
+      outline: "none",
+      width: "240px",
+      textAlign: "center",
+    } as CSSStyleDeclaration);
+    document.body.appendChild(input);
+    return input;
+  }
+
+  private async handleLogin(): Promise<void> {
+    const name = this.nameInput.value.trim();
+    const password = this.passwordInput.value;
+    const result = await login(name, password);
+    if (result.ok) {
+      this.scene.start("HomeScreen");
+    } else {
+      this.errorText.setText(result.error ?? "ログインに失敗しました");
+    }
+  }
+
+  private async handleRegister(): Promise<void> {
+    const name = this.nameInput.value.trim();
+    const password = this.passwordInput.value;
+    const result = await register(name, password);
+    if (result.ok) {
+      this.scene.start("HomeScreen");
+    } else {
+      this.errorText.setText(result.error ?? "登録に失敗しました");
+    }
+  }
+}

--- a/client/src/ui/screens/LoginScreen.ts
+++ b/client/src/ui/screens/LoginScreen.ts
@@ -1,13 +1,22 @@
 import Phaser from "phaser";
 import { login, register, getSession } from "../../storage/auth";
+import { OceanBackgroundShader } from "../../game/objects/BackgroundShader";
 
 export class LoginScreen extends Phaser.Scene {
   private nameInput!: HTMLInputElement;
   private passwordInput!: HTMLInputElement;
   private errorText!: Phaser.GameObjects.Text;
+  private bgShader!: Phaser.GameObjects.Shader;
 
   constructor() {
     super({ key: "LoginScreen" });
+  }
+
+  preload(): void {
+    this.load.image("shark", "shark.png");
+    if (!this.cache.shader.has("OceanBackground")) {
+      this.cache.shader.add("OceanBackground", OceanBackgroundShader);
+    }
   }
 
   create(): void {
@@ -18,68 +27,131 @@ export class LoginScreen extends Phaser.Scene {
     }
 
     const { width, height } = this.scale;
-    this.cameras.main.setBackgroundColor("#001b44");
+
+    /* ── animated ocean background ── */
+    this.bgShader = this.add.shader(
+      "OceanBackground",
+      width / 2,
+      height / 2,
+      width,
+      height,
+    );
+
+    /* ── dark overlay panel ── */
+    const panelW = Math.min(420, width * 0.88);
+    const panelH = height * 0.72;
+    const panelX = width / 2;
+    const panelY = height * 0.52;
+
+    const panel = this.add.graphics();
+    panel.fillStyle(0x001020, 0.75);
+    panel.fillRoundedRect(
+      panelX - panelW / 2,
+      panelY - panelH / 2,
+      panelW,
+      panelH,
+      16,
+    );
+    panel.lineStyle(1, 0x335577, 0.5);
+    panel.strokeRoundedRect(
+      panelX - panelW / 2,
+      panelY - panelH / 2,
+      panelW,
+      panelH,
+      16,
+    );
+
+    /* ── shark logo ── */
+    const logo = this.add
+      .image(width / 2, height * 0.21, "shark")
+      .setOrigin(0.5);
+    const logoScale = Math.min(100 / logo.width, 80 / logo.height);
+    logo.setScale(logoScale).setAlpha(0.85).setTint(0x88ccee);
+
+    /* ── title ── */
+    this.add
+      .text(width / 2, height * 0.3, "サメザリオ", {
+        fontFamily: "system-ui, sans-serif",
+        fontSize: "48px",
+        color: "#a0ddff",
+      })
+      .setOrigin(0.5)
+      .setStroke("#0a3055", 6);
 
     this.add
-      .text(width / 2, height * 0.12, "サメザリオ", {
-        fontFamily: "system-ui",
-        fontSize: "56px",
-        color: "#88ccee",
+      .text(width / 2, height * 0.37, "Sign in to dive", {
+        fontFamily: "system-ui, sans-serif",
+        fontSize: "14px",
+        color: "#557799",
+        letterSpacing: 4,
       })
       .setOrigin(0.5);
 
-    this.add
-      .text(width / 2, height * 0.23, "ログイン", {
-        fontFamily: "system-ui",
-        fontSize: "28px",
-        color: "#ddeeff",
-      })
-      .setOrigin(0.5);
+    /* ── inputs ── */
+    this.nameInput = this.createInput("login-name", "名前", "46%", 16);
+    this.passwordInput = this.createInput(
+      "login-password",
+      "パスワード",
+      "54%",
+      32,
+      true,
+    );
 
-    this.nameInput = this.createInput("login-name", "名前を入力", "35%", 16);
-    this.passwordInput = this.createInput("login-password", "パスワード", "45%", 32, true);
-
+    /* ── error text ── */
     this.errorText = this.add
-      .text(width / 2, height * 0.53, "", {
-        fontFamily: "system-ui",
-        fontSize: "16px",
+      .text(width / 2, height * 0.6, "", {
+        fontFamily: "system-ui, sans-serif",
+        fontSize: "14px",
         color: "#ff6666",
         align: "center",
       })
       .setOrigin(0.5);
 
-    this.add
-      .text(width / 2, height * 0.62, "[ ログイン ]", {
-        fontFamily: "system-ui",
-        fontSize: "32px",
-        color: "#44ff88",
-      })
-      .setOrigin(0.5)
-      .setInteractive({ useHandCursor: true })
-      .on("pointerdown", () => this.handleLogin());
+    /* ── buttons ── */
+    this.createButton(
+      width / 2,
+      height * 0.67,
+      "ログイン",
+      panelW * 0.7,
+      44,
+      0x1a6040,
+      "#44ffaa",
+      () => this.handleLogin(),
+    );
 
-    this.add
-      .text(width / 2, height * 0.73, "[ 新規登録 ]", {
-        fontFamily: "system-ui",
-        fontSize: "28px",
-        color: "#ffaa44",
-      })
-      .setOrigin(0.5)
-      .setInteractive({ useHandCursor: true })
-      .on("pointerdown", () => this.handleRegister());
+    this.createButton(
+      width / 2,
+      height * 0.755,
+      "新規登録",
+      panelW * 0.7,
+      44,
+      0x2a4060,
+      "#88bbdd",
+      () => this.handleRegister(),
+    );
 
+    /* ── focus & keyboard ── */
     this.nameInput.focus();
-
     this.passwordInput.addEventListener("keydown", (e) => {
       if (e.key === "Enter") this.handleLogin();
     });
 
+    /* ── resize handler ── */
+    this.scale.on("resize", (sz: Phaser.Structs.Size) => {
+      if (this.bgShader) {
+        this.bgShader.setSize(sz.width, sz.height);
+        this.bgShader.setPosition(sz.width / 2, sz.height / 2);
+      }
+    });
+
+    /* ── cleanup ── */
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
       this.nameInput.remove();
       this.passwordInput.remove();
     });
   }
 
+  /* ── HTML input helper ── */
   private createInput(
     id: string,
     placeholder: string,
@@ -100,20 +172,89 @@ export class LoginScreen extends Phaser.Scene {
       left: "50%",
       top,
       transform: "translate(-50%, -50%)",
-      fontSize: "20px",
-      padding: "10px 16px",
-      borderRadius: "6px",
-      border: "1px solid #446688",
-      background: "#002b5c",
+      fontSize: "18px",
+      padding: "12px 20px",
+      borderRadius: "8px",
+      border: "1px solid #335577",
+      background: "rgba(0, 20, 50, 0.85)",
       color: "#ddeeff",
       outline: "none",
-      width: "240px",
+      width: "260px",
       textAlign: "center",
+      boxShadow: "0 0 12px rgba(68, 170, 255, 0.08), inset 0 1px 4px rgba(0,0,0,0.3)",
+      transition: "border-color 0.2s, box-shadow 0.2s",
     } as CSSStyleDeclaration);
+
+    input.addEventListener("focus", () => {
+      input.style.borderColor = "#44aaff";
+      input.style.boxShadow =
+        "0 0 16px rgba(68, 170, 255, 0.2), inset 0 1px 4px rgba(0,0,0,0.3)";
+    });
+    input.addEventListener("blur", () => {
+      input.style.borderColor = "#335577";
+      input.style.boxShadow =
+        "0 0 12px rgba(68, 170, 255, 0.08), inset 0 1px 4px rgba(0,0,0,0.3)";
+    });
+
     document.body.appendChild(input);
     return input;
   }
 
+  /* ── canvas button helper ── */
+  private createButton(
+    x: number,
+    y: number,
+    label: string,
+    w: number,
+    h: number,
+    bgColor: number,
+    textColor: string,
+    onClick: () => void,
+  ): void {
+    const bg = this.add.graphics();
+    bg.fillStyle(bgColor, 0.9);
+    bg.fillRoundedRect(x - w / 2, y - h / 2, w, h, 8);
+    bg.lineStyle(1, 0x44aaff, 0.15);
+    bg.strokeRoundedRect(x - w / 2, y - h / 2, w, h, 8);
+
+    const txt = this.add
+      .text(x, y, label, {
+        fontFamily: "system-ui, sans-serif",
+        fontSize: "20px",
+        fontStyle: "bold",
+        color: textColor,
+      })
+      .setOrigin(0.5);
+
+    const hitArea = new Phaser.Geom.Rectangle(
+      x - w / 2,
+      y - h / 2,
+      w,
+      h,
+    );
+    const hitZone = this.add
+      .zone(x, y, w, h)
+      .setInteractive({ hitArea, hitAreaCallback: Phaser.Geom.Rectangle.Contains, useHandCursor: true })
+      .on("pointerover", () => {
+        bg.clear();
+        bg.fillStyle(bgColor, 1.0);
+        bg.fillRoundedRect(x - w / 2, y - h / 2, w, h, 8);
+        bg.lineStyle(1, 0x66ccff, 0.4);
+        bg.strokeRoundedRect(x - w / 2, y - h / 2, w, h, 8);
+        txt.setScale(1.03);
+      })
+      .on("pointerout", () => {
+        bg.clear();
+        bg.fillStyle(bgColor, 0.9);
+        bg.fillRoundedRect(x - w / 2, y - h / 2, w, h, 8);
+        bg.lineStyle(1, 0x44aaff, 0.15);
+        bg.strokeRoundedRect(x - w / 2, y - h / 2, w, h, 8);
+        txt.setScale(1.0);
+      })
+      .on("pointerdown", onClick);
+  }
+
+  /* ── auth handlers ── */
   private async handleLogin(): Promise<void> {
     const name = this.nameInput.value.trim();
     const password = this.passwordInput.value;


### PR DESCRIPTION
- 新規 CPScreen: Haversine で移動距離を算出し 50 m = 1 CP で加算 (1 セッション上限 100 CP)
- 所持 CP は localStorage (samether_cp) に永続化、 NaN ガード付きの共通ユーティリティ storage/cp.ts を追加
- Goal ボタンは create() で一度だけハンドラ登録し、 phase state で enable/disable を切替 (二重登録バグ対策)
- HomeScreen に [ CP 獲得 ] ボタンと所持 CP 表示を追加、 CPScreen を main.ts の scene 配列に登録