### PR TITLE
Person 3: 死亡画面の種族名をルートに応じて正しく表示

### DIFF
--- a/client/src/game/scenes/GameScene.ts
+++ b/client/src/game/scenes/GameScene.ts
@@ -458,7 +458,7 @@ export class GameScene extends Phaser.Scene {
   }
 
   private onDeath(m: DeathPayload): void {
-    this.scene.start("DeathScreen", { score: m.score, stage: m.stage });
+    this.scene.start("DeathScreen", { score: m.score, stage: m.stage, route: this.myRoute });
   }
 
   private onLeaderboard(m: LeaderboardPayload): void {

--- a/client/src/ui/screens/DeathScreen.ts
+++ b/client/src/ui/screens/DeathScreen.ts
@@ -1,24 +1,25 @@
 import Phaser from "phaser";
+import type { SharkRoute } from "../../network/protocol";
 
-const STAGE_NAMES: Record<number, string[]> = {
-  0: ["シュモクザメ", "ドチザメ", "ツラナガコビトザメ"],
-  1: ["イタチザメ", "ネムリブカ", "ノコギリザメ"],
-  2: ["アオザメ", "シロワニ", "ラブカ"],
-  3: ["ホオジロザメ", "ウバザメ", "ミツクリザメ"],
-  4: ["メガロドン", "ジンベエザメ", "ニシオンデンザメ"],
+const ROUTE_STAGE_NAMES: Record<SharkRoute, string[]> = {
+  "attack": ["シュモクザメ", "イタチザメ", "アオザメ", "ホオジロザメ", "メガロドン"],
+  "non-attack": ["ドチザメ", "ネムリブカ", "シロワニ", "ウバザメ", "ジンベエザメ"],
+  "deep-sea": ["ツラナガコビトザメ", "ノコギリザメ", "ラブカ", "ミツクリザメ", "ニシオンデンザメ"],
 };
 
 export class DeathScreen extends Phaser.Scene {
   private score = 0;
   private stage = 0;
+  private route: SharkRoute = "attack";
 
   constructor() {
     super({ key: "DeathScreen" });
   }
 
-  init(data: { score: number; stage: number }): void {
+  init(data: { score: number; stage: number; route?: SharkRoute }): void {
     this.score = data.score;
     this.stage = data.stage;
+    this.route = data.route ?? "attack";
   }
 
   create(): void {
@@ -92,8 +93,8 @@ export class DeathScreen extends Phaser.Scene {
 
     /* ── score / stage info (fade in after main text) ── */
     const stageIndex = Math.max(0, this.stage - 1);
-    const stageName =
-      STAGE_NAMES[stageIndex]?.[0] ?? `Stage ${this.stage}`;
+    const names = ROUTE_STAGE_NAMES[this.route];
+    const stageName = names[Math.min(stageIndex, names.length - 1)];
 
     const infoText = this.add
       .text(


### PR DESCRIPTION
## Summary
死亡画面で常に攻撃系の種族名が表示されるバグを修正。選択ルートに応じた正しい種族名を表示。

## 変更内容
- `GameScene.onDeath`: `route` を DeathScreen に渡す
- `DeathScreen`: `ROUTE_STAGE_NAMES` をルート別に定義し、`route` に応じた種族名を表示

## 修正前 → 修正後
- 非攻撃系で死亡: ~~シュモクザメ~~ → **ドチザメ**
- 深海魚系で死亡: ~~シュモクザメ~~ → **ツラナガコビトザメ**

## Test plan
- [x] 各ルートで死亡 → 正しい種族名が表示される