### PR TITLE
Person 3: 進化通知の毎tick発火を修正

### DIFF
--- a/client/src/game/scenes/GameScene.ts
+++ b/client/src/game/scenes/GameScene.ts
@@ -43,6 +43,7 @@ export class GameScene extends Phaser.Scene {
   private myId = "";
   private myName = "";
   private myRoute: SharkRoute = "attack";
+  private lastStage = -1;
   private myStage = -1;
 
   /* entity state manager */
@@ -544,14 +545,13 @@ export class GameScene extends Phaser.Scene {
       /* XP bar */
       this.xpBar.update(m.you.xp, m.you.stage, this.myRoute);
 
-      /* Update territory manager with current level */
-      if (this.territoryManager && m.you.stage !== undefined) {
-        // Trigger evolution event if level changed
-        const currentLevel = m.you.stage;
+      /* Update territory manager with current level (only on actual change) */
+      if (this.territoryManager && m.you.stage !== undefined && m.you.stage !== this.lastStage) {
+        this.lastStage = m.you.stage;
         this.territoryManager.handleMessage({
           type: 'my_evolution',
           payload: {
-            newLevel: currentLevel,
+            newLevel: m.you.stage,
             recalculateTerritories: true,
           },
         });


### PR DESCRIPTION
## Summary
進化通知テキスト（「進化しました！レベル N」）が画面に積み重なって消えないバグを修正。

## 原因
`GameScene.onState()` で毎 tick（20回/秒）`my_evolution` メッセージを発火していた。stage が変わっていなくても毎回テキスト生成 → フェードアウト（2秒後）より速く積み重なるため消えない。

## 修正
- `lastStage` フィールドを追加（初期値 `-1`）
- `m.you.stage !== this.lastStage` のときだけ `my_evolution` を発火

## Test plan
- [x] ローカルで確認: 進化時に通知が 1 回だけ表示され、2 秒後にフェードアウトする
- [x] stage が変わらない間は通知が出ない

Fixes #62