### PR TITLE
Implement route-based territory and trail colors with client-side filtering                                                

### DIFF
--- a/client/src/game/config/RouteColors.ts
+++ b/client/src/game/config/RouteColors.ts
@@ -1,0 +1,40 @@
+/**
+ * RouteColors.ts
+ *
+ * Centralized color configuration for shark routes.
+ * Used across territories, trails, and UI elements.
+ */
+
+import type { SharkRoute } from "../../network/protocol";
+
+export const ROUTE_COLORS: Record<SharkRoute, number> = {
+  "attack": 0xff6666,     // Red
+  "non-attack": 0x66ccff, // Blue
+  "deep-sea": 0xbb66ff,   // Purple
+};
+
+export const ROUTE_COLORS_HEX: Record<SharkRoute, string> = {
+  "attack": "#ff6666",
+  "non-attack": "#66ccff",
+  "deep-sea": "#bb66ff",
+};
+
+/**
+ * Get route color as number (0xRRGGBB)
+ */
+export function getRouteColor(route: SharkRoute): number {
+  return ROUTE_COLORS[route];
+}
+
+/**
+ * Get route color as hex string (#RRGGBB)
+ */
+export function getRouteColorHex(route: SharkRoute): string {
+  return ROUTE_COLORS_HEX[route];
+}
+
+/**
+ * Orange color for dangerous territories (higher level)
+ */
+export const DANGER_COLOR = 0xff6600;
+export const DANGER_COLOR_HEX = "#ff6600";

--- a/client/src/game/objects/Shark.ts
+++ b/client/src/game/objects/Shark.ts
@@ -1,17 +1,12 @@
 import Phaser from "phaser";
 import { SharkRoute } from "../../network/protocol";
 import { TerritoryRenderer } from "./TerritoryRenderer";
+import { getRouteColor } from "../config/RouteColors";
 
 /* ── colours tuned to look like semi-transparent grey
       silhouettes against the dark ocean ──────────────────── */
 const BODY_COLORS = [0x708898, 0x668090, 0x5c7488, 0x526880, 0x485c78];
 const SIZE_SCALES = [1.3, 1.45, 1.6, 1.8, 2.05];
-
-const ROUTE_GLOW_COLORS: Record<SharkRoute, number> = {
-  "attack": 0xff6666,     // UIと同じ赤
-  "non-attack": 0x66ccff, // UIと同じ青
-  "deep-sea": 0xbb66ff    // UIと同じ紫
-};
 
 function resolveSharkTextureKey(stage: number, route: SharkRoute): string {
   if (stage <= 1) return "shark_stage01";
@@ -99,7 +94,7 @@ export class Shark extends Phaser.GameObjects.Container {
       rope.postFX.clear();
       // Increase padding to ensure the outer glow doesn't get clipped by the bounds
       rope.postFX.setPadding(32);
-      const glowColor = ROUTE_GLOW_COLORS[this.route];
+      const glowColor = getRouteColor(this.route);
       // addGlow(color, outerStrength, innerStrength, knockout, threshold, distance)
       rope.postFX.addGlow(glowColor, 4, 0, false, 0.1, 10);
     }

--- a/client/src/game/scenes/GameScene.ts
+++ b/client/src/game/scenes/GameScene.ts
@@ -19,6 +19,7 @@ import { LeaderboardPanel } from "../hud/LeaderboardPanel";
 import { GameState } from "../state/GameState";
 import { TerritoryManager } from "../territory/TerritoryManager";
 import { SuctionEffect } from "../effects/SuctionEffect";
+import { getRouteColor } from "../config/RouteColors";
 
 /* ── constants ─────────────────────────────────────────────── */
 const STAGE_ZOOMS = [1.0, 0.82, 0.65, 0.48, 0.35];
@@ -156,7 +157,7 @@ export class GameScene extends Phaser.Scene {
     this.radarRenderer = new RadarRenderer(this, this.uiContainer);
 
     /* ── Territory System ────────────────── */
-    this.territoryManager = new TerritoryManager(this);
+    this.territoryManager = new TerritoryManager(this, this.myRoute);
     // Will be initialized with player ID and level in onWelcome
 
     /* Camera setup: Main camera ignores UI, UI camera ignores World */
@@ -410,13 +411,9 @@ export class GameScene extends Phaser.Scene {
       return;
     }
 
-    const routeColor = this.myRoute ? {
-      attack: 0xff9999,
-      "non-attack": 0x99d4ff,
-      "deep-sea": 0xd099ff,
-    }[this.myRoute] : 0x88ccff;
+    const routeColor = getRouteColor(this.myRoute);
 
-    this.trailGraphics.lineStyle(4, routeColor || 0x88ccff, 0.6);
+    this.trailGraphics.lineStyle(4, routeColor, 0.6);
     this.trailGraphics.beginPath();
     this.trailGraphics.moveTo(this.pointerTrail[0].x, this.pointerTrail[0].y);
     for (let i = 1; i < this.pointerTrail.length; i++) {

--- a/client/src/game/territory/TerritoryCache.ts
+++ b/client/src/game/territory/TerritoryCache.ts
@@ -5,10 +5,14 @@
  * Only stores and manages territories that are relevant to the current player.
  */
 
+import type { SharkRoute } from "../../network/protocol";
+
 export interface Point {
   x: number;
   y: number;
 }
+
+export type TerritoryColor = 'route' | 'danger' | null;
 
 export interface Territory {
   id: string;
@@ -16,7 +20,8 @@ export interface Territory {
   level: number;
   polygon: Point[];
   expiresAt: number;
-  color?: 'green' | 'orange' | 'gray';
+  route?: SharkRoute;
+  color?: TerritoryColor;
 }
 
 export class TerritoryCache {
@@ -98,25 +103,25 @@ export class TerritoryCache {
   }
 
   /**
-   * Get territories by color
+   * Get territories by color type
    */
-  getByColor(color: 'green' | 'orange' | 'gray'): Territory[] {
+  getByColor(color: TerritoryColor): Territory[] {
     return Array.from(this.territories.values())
       .filter(t => t.color === color);
   }
 
   /**
-   * Get only dangerous territories (orange)
+   * Get only dangerous territories (higher level, orange)
    */
   getDangerousTerritories(): Territory[] {
-    return this.getByColor('orange');
+    return this.getByColor('danger');
   }
 
   /**
-   * Get only own territories (green)
+   * Get only own territories (route color)
    */
   getMyTerritories(): Territory[] {
-    return this.getByColor('green');
+    return this.getByColor('route');
   }
 
   /**
@@ -166,23 +171,18 @@ export class TerritoryCache {
    * Calculate the display color for a territory
    * Returns null if the territory should not be displayed
    */
-  private calculateColor(territory: Territory): 'green' | 'orange' | 'gray' | null {
-    // Own territories are always green
+  private calculateColor(territory: Territory): TerritoryColor {
+    // Own territories use route color
     if (territory.sharkId === this.mySharkId) {
-      return 'green';
+      return 'route';
     }
 
     // Higher level territories are dangerous (orange)
     if (territory.level > this.myLevel) {
-      return 'orange';
+      return 'danger';
     }
 
-    // Same level territories are neutral (gray) - optional display
-    if (territory.level === this.myLevel) {
-      return 'gray';
-    }
-
-    // Lower level territories are not displayed
+    // Same level or lower territories are not displayed
     return null;
   }
 

--- a/client/src/game/territory/TerritoryManager.ts
+++ b/client/src/game/territory/TerritoryManager.ts
@@ -8,6 +8,7 @@
 import Phaser from 'phaser';
 import { TerritoryCache, Territory, Point } from './TerritoryCache';
 import { TerritoryRenderer } from './TerritoryRenderer';
+import type { SharkRoute } from '../../network/protocol';
 
 export interface TerritoryCreatedMessage {
   type: 'territory_created';
@@ -51,12 +52,14 @@ export class TerritoryManager {
   private renderer: TerritoryRenderer;
   private mySharkId: string | null = null;
   private myLevel: number = 1;
+  private myRoute: SharkRoute;
   private scene: Phaser.Scene;
 
-  constructor(scene: Phaser.Scene) {
+  constructor(scene: Phaser.Scene, myRoute: SharkRoute) {
     this.scene = scene;
+    this.myRoute = myRoute;
     this.cache = new TerritoryCache();
-    this.renderer = new TerritoryRenderer(scene, this.cache);
+    this.renderer = new TerritoryRenderer(scene, this.cache, myRoute);
   }
 
   /**

--- a/client/src/game/territory/TerritoryRenderer.ts
+++ b/client/src/game/territory/TerritoryRenderer.ts
@@ -7,6 +7,8 @@
 
 import * as Phaser from 'phaser';
 import { Territory, TerritoryCache, Point } from './TerritoryCache';
+import type { SharkRoute } from '../../network/protocol';
+import { getRouteColor, DANGER_COLOR } from '../config/RouteColors';
 
 export class TerritoryRenderer {
   private scene: Phaser.Scene;
@@ -14,34 +16,33 @@ export class TerritoryRenderer {
   private graphics: Phaser.GameObjects.Graphics;
   private warningIcons: Map<string, Phaser.GameObjects.Text> = new Map();
   private dangerousWarningIds: Set<string> = new Set();
+  private myRoute: SharkRoute;
 
-  // Visual settings
-  private colors = {
-    green: {
-      line: 0x00ff00,
-      fill: 0x00ff00,
-      lineAlpha: 0.8,
-      fillAlpha: 0.2,
-    },
-    orange: {
-      line: 0xff6600,
-      fill: 0xff6600,
-      lineAlpha: 0.9,
-      fillAlpha: 0.3,
-    },
-    gray: {
-      line: 0x888888,
-      fill: 0x888888,
-      lineAlpha: 0.6,
-      fillAlpha: 0.15,
-    },
+  // Visual settings for danger color
+  private dangerStyle = {
+    lineAlpha: 0.9,
+    fillAlpha: 0.3,
   };
 
-  constructor(scene: Phaser.Scene, cache: TerritoryCache) {
+  // Visual settings for route colors
+  private routeStyle = {
+    lineAlpha: 0.8,
+    fillAlpha: 0.2,
+  };
+
+  constructor(scene: Phaser.Scene, cache: TerritoryCache, myRoute: SharkRoute) {
     this.scene = scene;
     this.cache = cache;
+    this.myRoute = myRoute;
     this.graphics = scene.add.graphics();
     this.graphics.setDepth(5); // Below sharks, above background
+  }
+
+  /**
+   * Update player's route (for color changes)
+   */
+  setMyRoute(route: SharkRoute): void {
+    this.myRoute = route;
   }
 
   /**
@@ -57,12 +58,9 @@ export class TerritoryRenderer {
     const dangerousTerritories = this.cache.getDangerousTerritories();
     this.syncWarningIcons(dangerousTerritories);
 
-    // Draw territories by priority: own (green) first, then dangerous (orange)
-    this.renderTerritories(this.cache.getMyTerritories(), 'green');
-    this.renderTerritories(dangerousTerritories, 'orange');
-
-    // Optionally draw neutral territories (same level)
-    // this.renderTerritories(this.cache.getByColor('gray'), 'gray');
+    // Draw territories by priority: own (route color) first, then dangerous (orange)
+    this.renderMyTerritories(this.cache.getMyTerritories());
+    this.renderDangerousTerritories(dangerousTerritories);
   }
 
   /**
@@ -95,13 +93,25 @@ export class TerritoryRenderer {
   }
 
   /**
-   * Render territories of a specific color
+   * Render own territories with route color
    */
-  private renderTerritories(territories: Territory[], color: 'green' | 'orange' | 'gray'): void {
-    const style = this.colors[color];
+  private renderMyTerritories(territories: Territory[]): void {
+    const routeColor = getRouteColor(this.myRoute);
 
-    this.graphics.lineStyle(3, style.line, style.lineAlpha);
-    this.graphics.fillStyle(style.fill, style.fillAlpha);
+    this.graphics.lineStyle(3, routeColor, this.routeStyle.lineAlpha);
+    this.graphics.fillStyle(routeColor, this.routeStyle.fillAlpha);
+
+    for (const territory of territories) {
+      this.drawPolygon(territory.polygon);
+    }
+  }
+
+  /**
+   * Render dangerous territories with orange color
+   */
+  private renderDangerousTerritories(territories: Territory[]): void {
+    this.graphics.lineStyle(3, DANGER_COLOR, this.dangerStyle.lineAlpha);
+    this.graphics.fillStyle(DANGER_COLOR, this.dangerStyle.fillAlpha);
 
     for (const territory of territories) {
       this.drawPolygon(territory.polygon);

--- a/server/internal/game/territory_manager.go
+++ b/server/internal/game/territory_manager.go
@@ -10,7 +10,8 @@ import (
 type Territory struct {
 	ID        string    `json:"id"`
 	SharkID   string    `json:"sharkId"`
-	Level     int       `json:"level"` // Shark evolution level (1-5)
+	Route     string    `json:"route"`    // Shark route type: "attack", "non-attack", "deep-sea"
+	Level     int       `json:"level"`    // Shark evolution level (1-5)
 	Polygon   []Vec     `json:"polygon"`
 	BBox      BBox      `json:"bbox"`
 	CreatedAt int64     `json:"createdAt"` // Unix timestamp in milliseconds for WS/JSON payloads
@@ -43,7 +44,7 @@ func NewTerritoryManager(lifetime time.Duration) *TerritoryManager {
 }
 
 // CreateTerritory creates a new territory from a polygon
-func (tm *TerritoryManager) CreateTerritory(sharkID string, level int, polygon []Vec) *Territory {
+func (tm *TerritoryManager) CreateTerritory(sharkID string, route string, level int, polygon []Vec) *Territory {
 	tm.mu.Lock()
 	defer tm.mu.Unlock()
 
@@ -51,6 +52,7 @@ func (tm *TerritoryManager) CreateTerritory(sharkID string, level int, polygon [
 	territory := &Territory{
 		ID:        fmt.Sprintf("%s_territory_%d", sharkID, now.UnixNano()),
 		SharkID:   sharkID,
+		Route:     route,
 		Level:     level,
 		Polygon:   polygon,
 		BBox:      calculateBBox(polygon),

--- a/server/internal/game/territory_manager_test.go
+++ b/server/internal/game/territory_manager_test.go
@@ -16,7 +16,7 @@ func TestTerritoryManager_CreateTerritory(t *testing.T) {
 		{X: 0, Y: 0},
 	}
 
-	territory := tm.CreateTerritory("shark1", 2, polygon)
+	territory := tm.CreateTerritory("shark1", "attack", 2, polygon)
 
 	if territory == nil {
 		t.Fatal("Expected territory to be created")
@@ -41,8 +41,8 @@ func TestTerritoryManager_UpdateSharkLevel(t *testing.T) {
 	polygon := []Vec{{X: 0, Y: 0}, {X: 100, Y: 0}, {X: 100, Y: 100}, {X: 0, Y: 0}}
 
 	// Create two territories for the same shark
-	t1 := tm.CreateTerritory("shark1", 2, polygon)
-	t2 := tm.CreateTerritory("shark1", 2, polygon)
+	t1 := tm.CreateTerritory("shark1", "attack", 2, polygon)
+	t2 := tm.CreateTerritory("shark1", "attack", 2, polygon)
 
 	// Evolve the shark
 	updated := tm.UpdateSharkLevel("shark1", 3)
@@ -73,7 +73,7 @@ func TestTerritoryManager_CheckCollision(t *testing.T) {
 		{X: 0, Y: 0},
 	}
 
-	tm.CreateTerritory("shark1", 3, polygon)
+	tm.CreateTerritory("shark1", "attack", 3, polygon)
 
 	tests := []struct {
 		name        string
@@ -142,8 +142,8 @@ func TestTerritoryManager_RemoveExpired(t *testing.T) {
 
 	polygon := []Vec{{X: 0, Y: 0}, {X: 100, Y: 0}, {X: 100, Y: 100}, {X: 0, Y: 0}}
 
-	tm.CreateTerritory("shark1", 2, polygon)
-	tm.CreateTerritory("shark2", 3, polygon)
+	tm.CreateTerritory("shark1", "attack", 2, polygon)
+	tm.CreateTerritory("shark2", "non-attack", 3, polygon)
 
 	if tm.Count() != 2 {
 		t.Errorf("Expected 2 territories, got %d", tm.Count())
@@ -169,9 +169,9 @@ func TestTerritoryManager_RemoveSharkTerritories(t *testing.T) {
 	polygon := []Vec{{X: 0, Y: 0}, {X: 100, Y: 0}, {X: 100, Y: 100}, {X: 0, Y: 0}}
 
 	// Create territories for two sharks
-	tm.CreateTerritory("shark1", 2, polygon)
-	tm.CreateTerritory("shark1", 2, polygon)
-	tm.CreateTerritory("shark2", 3, polygon)
+	tm.CreateTerritory("shark1", "attack", 2, polygon)
+	tm.CreateTerritory("shark1", "attack", 2, polygon)
+	tm.CreateTerritory("shark2", "non-attack", 3, polygon)
 
 	if tm.Count() != 3 {
 		t.Errorf("Expected 3 territories, got %d", tm.Count())

--- a/server/internal/ws/message.go
+++ b/server/internal/ws/message.go
@@ -187,6 +187,7 @@ func EncodeLeaderboard(l LeaderboardPayload) []byte {
 type TerritoryPayload struct {
 	ID        string  `json:"id"`
 	SharkID   string  `json:"sharkId"`
+	Route     string  `json:"route"`
 	Level     int     `json:"level"`
 	Polygon   []Point `json:"polygon"`
 	ExpiresAt int64   `json:"expiresAt"`


### PR DESCRIPTION
本文                                                                                                                     
                                                                                                                           
  ## 概要                                                                                                                  
  領域と軌跡の色を種族別（攻撃系=赤、非攻撃系=青、深海魚系=紫）に対応し、クライアント側でレベルベースのフィルタリングを実装
  しました。                                                                                                               
                  
  ## 変更内容                                                                                                              
                  
  ### 🎨 色管理の一元化                                                                                                    
  - **新規ファイル**: `RouteColors.ts` で種族色と危険色を定義
    - 攻撃系: `#ff6666` (赤)                                                                                               
    - 非攻撃系: `#66ccff` (青)                                                                                             
    - 深海魚系: `#bb66ff` (紫)                                                                                             
    - 危険領域: `#ff6600` (オレンジ)                                                                                       
                                                                                                                           
  ### 📍 領域の表示ルール（クライアント側フィルタリング）                                                                  
  - **自分の領域**: 種族色で表示（赤/青/紫）                                                                               
  - **レベルが高い領域**: オレンジ色で表示（危険マーク付き）                                                               
  - **同レベル以下の領域**: 非表示（視覚的ノイズ削減）                                                                     
                                                                                                                           
  ### 🖌️  軌跡(Trail)の色                                                                                                   
  - プレイヤーの種族色で統一表示                                                                                           
                                                                                                                           
  ### 📡 通信量削減の仕組み                                                                                                
  1. **サーバー**: 全領域データに`route`情報を追加して送信                                                                 
  2. **クライアント**: 各プレイヤーのレベルに応じてフィルタリング・配色                                                    
  3. **更新タイミング**: 進化イベント発生時のみ（`my_evolution`メッセージ）                                                
                                                                                                                           
  ## 技術的変更                                                                                                            
                                                                                                                           
  ### Client                                                                                                               
  - `TerritoryCache`: 色タイプを`'route' | 'danger' | null`に変更
  - `TerritoryRenderer`: 種族色とオレンジ色を分離レンダリング                                                              
  - `GameScene`: 軌跡描画で`RouteColors`を使用                                                                             
  - `Shark`: グロー効果で`RouteColors`を使用                                                                               
                                                                                                                           
  ### Server                                                                                                               
  - `Territory`: `Route`フィールド追加                                                                                     
  - `CreateTerritory()`: `route`パラメータ追加                                                                             
  - `TerritoryPayload`: WebSocketメッセージに`route`追加                                                                   
  - テスト: 全ての`CreateTerritory`呼び出しを更新                                                                          
                                                                                                                           
  ## 変更ファイル                                                                                                          
   client/src/game/config/RouteColors.ts          | 40 ++++++++++++++                                                      
   client/src/game/objects/Shark.ts               |  9 +---                                                                
   client/src/game/scenes/GameScene.ts            | 11 ++--
   client/src/game/territory/TerritoryCache.ts    | 34 ++++++------                                                        
   client/src/game/territory/TerritoryManager.ts  |  7 ++-                                                                 
   client/src/game/territory/TerritoryRenderer.ts | 74 +++++++++++++++-----------                                          
   server/internal/game/territory_manager.go      |  6 ++-                                                                 
   server/internal/game/territory_manager_test.go | 18 +++----                                                             
   server/internal/ws/message.go                  |  1 +                                                                   
   9 files changed, 124 insertions(+), 76 deletions(-)                                                                     
                                                                                                                           
  ## テスト                                                                                                                
  - [x] サーバーテスト: `territory_manager_test.go`を全て更新                                                              
  - [x] TypeScriptビルド: 型チェック通過                                                                                   
  - [ ] 手動テスト: 各種族で領域と軌跡の色を確認                                                                           
                                                                                                                           
  ## チェックリスト                                                                                                        
  - [x] コードが正常にビルドできる                                                                                         
  - [x] テストが通過する                                                                                                   
  - [x] コミットメッセージが明確                                                                                           
  - [x] ドキュメント不要（コード内コメント充実）                                                                           
                                                                                                                           
  上記URLにアクセスして「Create pull request」ボタンをクリックし、タイトルと本文を貼り付けてPRを作成してください。 