### PR TITLE
fix(client): CPScreenをサーバー連携に修正し、GPS誤差による距離誤加算を解消 & 地図表示を追加

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -14,10 +14,19 @@
         font-family: system-ui, sans-serif;
       }
       #game { width: 100vw; height: 100vh; }
+      #cp-map {
+        display: none;
+        position: absolute;
+        top: 0; left: 0;
+        width: 100vw; height: 50vh;
+        z-index: 10;
+      }
     </style>
+    <link rel="stylesheet" href="https://unpkg.com/maplibre-gl@4.7.1/dist/maplibre-gl.css" />
   </head>
   <body>
     <div id="game"></div>
+    <div id="cp-map"></div>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,7 @@
       "name": "samezario-client",
       "version": "0.0.1",
       "dependencies": {
+        "maplibre-gl": "^5.23.0",
         "phaser": "^3.80.1"
       },
       "devDependencies": {
@@ -48,6 +49,111 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-1.1.0.tgz",
+      "integrity": "sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==",
+      "license": "ISC"
+    },
+    "node_modules/@mapbox/tiny-sdf": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.1.0.tgz",
+      "integrity": "sha512-uFJhNh36BR4OCuWIEiWaEix9CA2WzT6CAIcqVjWYpnx8+QDtS+oC4QehRrx5cX4mgWs37MmKnwUejeHxVymzNg==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
+      "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/@mapbox/vector-tile": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-2.0.4.tgz",
+      "integrity": "sha512-AkOLcbgGTdXScosBWwmmD7cDlvOjkg/DetGva26pIRiZPdeJYjYKarIlb4uxVzi6bwHO6EWH82eZ5Nuv4T5DUg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/point-geometry": "~1.1.0",
+        "@types/geojson": "^7946.0.16",
+        "pbf": "^4.0.1"
+      }
+    },
+    "node_modules/@mapbox/whoots-js": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
+      "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@maplibre/geojson-vt": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-6.1.0.tgz",
+      "integrity": "sha512-2eIY4gZxeKIVOZVNkAMb+5NgXhgsMQpOveTQAvnp53LYqHGJZDidk7Ew0Tged9PThidpbS+NFTh0g4zivhPDzQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
+      }
+    },
+    "node_modules/@maplibre/maplibre-gl-style-spec": {
+      "version": "24.8.1",
+      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-24.8.1.tgz",
+      "integrity": "sha512-zxa92qF96ZNojLxeAjnaRpjVCy+swoUNJvDhtpC90k7u5F0TMr4GmvNqMKvYrMoPB8d7gRSXbMG1hBbmgESIsw==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/unitbezier": "^0.0.1",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "minimist": "^1.2.8",
+        "quickselect": "^3.0.0",
+        "rw": "^1.3.3",
+        "tinyqueue": "^3.0.0"
+      },
+      "bin": {
+        "gl-style-format": "dist/gl-style-format.mjs",
+        "gl-style-migrate": "dist/gl-style-migrate.mjs",
+        "gl-style-validate": "dist/gl-style-validate.mjs"
+      }
+    },
+    "node_modules/@maplibre/mlt": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@maplibre/mlt/-/mlt-1.1.8.tgz",
+      "integrity": "sha512-8vtfYGidr1rNkv5IwIoU2lfe3Oy+Wa8HluzQYcQi9cveU9K3pweAal/poQj4GJ0K/EW4bTQp2wVAs09g2yDRZg==",
+      "license": "(MIT OR Apache-2.0)",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0"
+      }
+    },
+    "node_modules/@maplibre/vt-pbf": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@maplibre/vt-pbf/-/vt-pbf-4.3.0.tgz",
+      "integrity": "sha512-jIvp8F5hQCcreqOOpEt42TJMUlsrEcpf/kI1T2v85YrQRV6PPXUcEXUg5karKtH6oh47XJZ4kHu56pUkOuqA7w==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/vector-tile": "^2.0.4",
+        "@maplibre/geojson-vt": "^5.0.4",
+        "@types/geojson": "^7946.0.16",
+        "@types/supercluster": "^7.1.3",
+        "pbf": "^4.0.1",
+        "supercluster": "^8.0.1"
+      }
+    },
+    "node_modules/@maplibre/vt-pbf/node_modules/@maplibre/geojson-vt": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@maplibre/geojson-vt/-/geojson-vt-5.0.4.tgz",
+      "integrity": "sha512-KGg9sma45S+stfH9vPCJk1J0lSDLWZgCT9Y8u8qWZJyjFlP8MNP1WGTxIMYJZjDvVT3PDn05kN1C95Sut1HpgQ==",
+      "license": "ISC"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
@@ -353,6 +459,21 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/supercluster": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
+      "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -362,6 +483,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/earcut": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
+      "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
+      "license": "ISC"
     },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
@@ -401,6 +528,24 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
+      "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
+      "license": "MIT"
+    },
+    "node_modules/kdbush": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
+      "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
+      "license": "ISC"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",
@@ -663,6 +808,55 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/maplibre-gl": {
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-5.23.0.tgz",
+      "integrity": "sha512-aou8YBNFS8uVtDWFWt0W/6oorfl18wt+oIA8fnXk1kivjkbtXi9gGrQvflTpwrR3hG13aWdIdbYWeN0NFMV7ag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "^2.0.2",
+        "@mapbox/point-geometry": "^1.1.0",
+        "@mapbox/tiny-sdf": "^2.0.7",
+        "@mapbox/unitbezier": "^0.0.1",
+        "@mapbox/vector-tile": "^2.0.4",
+        "@mapbox/whoots-js": "^3.1.0",
+        "@maplibre/geojson-vt": "^6.1.0",
+        "@maplibre/maplibre-gl-style-spec": "^24.8.1",
+        "@maplibre/mlt": "^1.1.8",
+        "@maplibre/vt-pbf": "^4.3.0",
+        "@types/geojson": "^7946.0.16",
+        "earcut": "^3.0.2",
+        "gl-matrix": "^3.4.4",
+        "kdbush": "^4.0.2",
+        "murmurhash-js": "^1.0.0",
+        "pbf": "^4.0.1",
+        "potpack": "^2.1.0",
+        "quickselect": "^3.0.0",
+        "tinyqueue": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.14.0",
+        "npm": ">=8.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/maplibre/maplibre-gl-js?sponsor=1"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/murmurhash-js": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
+      "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -680,6 +874,18 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/pbf": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-4.0.1.tgz",
+      "integrity": "sha512-SuLdBvS42z33m8ejRbInMapQe8n0D3vN/Xd5fmWM3tufNgRQFBpaW2YVJxQZV4iPNqb0vEFvssMEo5w9c6BTIA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
       }
     },
     "node_modules/phaser": {
@@ -740,6 +946,33 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/potpack": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
+      "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
+      "license": "ISC"
+    },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
+      "license": "MIT"
+    },
+    "node_modules/quickselect": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
+      "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
+      "license": "ISC"
+    },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.0.0-rc.15",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.15.tgz",
@@ -774,6 +1007,12 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.15"
       }
     },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -782,6 +1021,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supercluster": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
+      "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
+      "license": "ISC",
+      "dependencies": {
+        "kdbush": "^4.0.2"
       }
     },
     "node_modules/tinyglobby": {
@@ -800,6 +1048,12 @@
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
+    },
+    "node_modules/tinyqueue": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
+      "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
+      "license": "ISC"
     },
     "node_modules/tslib": {
       "version": "2.8.1",

--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,7 @@
     "build": "tsc --noEmit && vite build"
   },
   "dependencies": {
+    "maplibre-gl": "^5.23.0",
     "phaser": "^3.80.1"
   },
   "devDependencies": {

--- a/client/src/network/protocol.ts
+++ b/client/src/network/protocol.ts
@@ -8,12 +8,16 @@ export type BaseMessage<T extends string, P> = {
 };
 
 // Client → Server
-export type JoinMsg = BaseMessage<"join", { 
-  name: string; 
+export type JoinMsg = BaseMessage<"join", {
+  name: string;
   route: SharkRoute; // TODO: Server-side support is pending. Currently ignored by the server.
 }>;
 export type InputMsg = BaseMessage<"input", { angle: number; dash: boolean; draw: boolean }>;
-export type ClientMsg = JoinMsg | InputMsg;
+export type CPStartMsg = BaseMessage<"cp_start", Record<string, never>>;
+export type CPUpdateMsg = BaseMessage<"cp_update", { lat: number; lon: number; acc: number }>;
+export type CPStopMsg = BaseMessage<"cp_stop", Record<string, never>>;
+export type CPBalanceMsg = BaseMessage<"cp_balance", Record<string, never>>;
+export type ClientMsg = JoinMsg | InputMsg | CPStartMsg | CPUpdateMsg | CPStopMsg | CPBalanceMsg;
 
 // Server → Client payloads
 export interface WelcomePayload {
@@ -77,9 +81,50 @@ export interface LeaderboardPayload {
   topScore: number;
 }
 
-// Server → Client messages 
+// Server → Client CP payloads
+export interface CPStartedPayload {
+  sessionId: string;
+}
+export interface CPProgressPayload {
+  pointsRecorded: number;
+  estimatedDist: number;
+}
+export interface CPPositionView {
+  lat: number;
+  lon: number;
+  ts?: string;
+}
+export interface CPResultPayload {
+  distance: number;
+  earned: number;
+  total: number;
+  positions: CPPositionView[];
+}
+export interface CPBalanceResultPayload {
+  total: number;
+}
+export interface CPErrorPayload {
+  code: string;
+  message: string;
+}
+
+// Server → Client messages
 export type WelcomeMsg = BaseMessage<"welcome", WelcomePayload>;
 export type StateMsg = BaseMessage<"state", StatePayload>;
 export type DeathMsg = BaseMessage<"death", DeathPayload>;
 export type LeaderboardMsg = BaseMessage<"leaderboard", LeaderboardPayload>;
-export type ServerMsg = WelcomeMsg | StateMsg | DeathMsg | LeaderboardMsg;
+export type CPStartedMsg = BaseMessage<"cp_started", CPStartedPayload>;
+export type CPProgressMsg = BaseMessage<"cp_progress", CPProgressPayload>;
+export type CPResultMsg = BaseMessage<"cp_result", CPResultPayload>;
+export type CPBalanceResultMsg = BaseMessage<"cp_balance_result", CPBalanceResultPayload>;
+export type CPErrorMsg = BaseMessage<"cp_error", CPErrorPayload>;
+export type ServerMsg =
+  | WelcomeMsg
+  | StateMsg
+  | DeathMsg
+  | LeaderboardMsg
+  | CPStartedMsg
+  | CPProgressMsg
+  | CPResultMsg
+  | CPBalanceResultMsg
+  | CPErrorMsg;

--- a/client/src/ui/screens/CPScreen.ts
+++ b/client/src/ui/screens/CPScreen.ts
@@ -1,26 +1,43 @@
 import Phaser from "phaser";
-import { addCp, loadCp } from "../../storage/cp";
+import maplibregl from "maplibre-gl";
+import { net } from "../../network/websocket";
+import { loadCp } from "../../storage/cp";
+import type { ServerMsg } from "../../network/protocol";
 
 const SERIF = "'Times New Roman', 'Georgia', serif";
 
-const METERS_PER_CP = 1;
-const MAX_EARN_PER_SESSION = 100;
-const GEO_TIMEOUT_MS = 10000;
+/** GPS送信間隔 (ms) — サーバーの5秒間隔フィルタに合わせる */
+const UPDATE_INTERVAL_MS = 5_000;
 
-type Phase = "idle" | "measuring" | "finalizing" | "done";
+type Phase = "idle" | "connecting" | "measuring" | "done";
 
 export class CPScreen extends Phaser.Scene {
   private cpDisplayText!: Phaser.GameObjects.Text;
   private statusText!: Phaser.GameObjects.Text;
+  private distText!: Phaser.GameObjects.Text;
   private startBtn!: Phaser.GameObjects.Text;
-  private goalBtn!: Phaser.GameObjects.Text;
+  private stopBtn!: Phaser.GameObjects.Text;
 
-  private startCoords: { lat: number; lon: number } | null = null;
   private phase: Phase = "idle";
+  private watchId: number | null = null;
+  private lastSendTime = 0;
+
+  /** 地図 */
+  private map: maplibregl.Map | null = null;
+  private trackCoords: [number, number][] = [];
+  private userMarker: maplibregl.Marker | null = null;
+
+  /** サーバーから受け取った最新値 */
+  private estimatedDist = 0;
+  private pointsRecorded = 0;
 
   constructor() {
     super({ key: "CPScreen" });
   }
+
+  /* ------------------------------------------------------------------ */
+  /*  Phaser lifecycle                                                   */
+  /* ------------------------------------------------------------------ */
 
   create(): void {
     const { width, height } = this.scale;
@@ -28,7 +45,7 @@ export class CPScreen extends Phaser.Scene {
 
     /* ── title ── */
     const title = this.add
-      .text(width / 2, height * 0.12, "C P  獲 得", {
+      .text(width / 2, height * 0.54, "C P  獲 得", {
         fontFamily: SERIF,
         fontSize: "52px",
         color: "#88ccee",
@@ -40,19 +57,19 @@ export class CPScreen extends Phaser.Scene {
       title.postFX.addGlow(0x225588, 6, 0, false, 0.1, 12);
     }
 
-    /* ── accent lines ── */
+    /* ── accent line ── */
     const lineW = width * 0.45;
     const lineX = (width - lineW) / 2;
     const lineGfx = this.add.graphics();
     lineGfx.lineStyle(1, 0x225588, 0.4);
     lineGfx.beginPath();
-    lineGfx.moveTo(lineX, height * 0.19);
-    lineGfx.lineTo(lineX + lineW, height * 0.19);
+    lineGfx.moveTo(lineX, height * 0.60);
+    lineGfx.lineTo(lineX + lineW, height * 0.60);
     lineGfx.strokePath();
 
     /* ── CP display ── */
     this.cpDisplayText = this.add
-      .text(width / 2, height * 0.25, `所持 CP: ${loadCp()}`, {
+      .text(width / 2, height * 0.64, `所持 CP: ${loadCp()}`, {
         fontFamily: SERIF,
         fontSize: "22px",
         color: "#6688aa",
@@ -63,8 +80,8 @@ export class CPScreen extends Phaser.Scene {
     this.add
       .text(
         width / 2,
-        height * 0.35,
-        `スタート地点で [ スタート ]、目的地で [ ゴール ] を押してください\n移動距離 ${METERS_PER_CP} m につき 1 CP (1 回最大 ${MAX_EARN_PER_SESSION} CP)`,
+        height * 0.70,
+        "[ スタート ] を押して歩くと自動で CP が貯まります",
         {
           fontFamily: SERIF,
           fontSize: "15px",
@@ -77,16 +94,25 @@ export class CPScreen extends Phaser.Scene {
 
     /* ── status ── */
     this.statusText = this.add
-      .text(width / 2, height * 0.48, "待機中", {
+      .text(width / 2, height * 0.76, "待機中", {
         fontFamily: SERIF,
         fontSize: "22px",
         color: "#4a6a8a",
       })
       .setOrigin(0.5);
 
+    /* ── distance display ── */
+    this.distText = this.add
+      .text(width / 2, height * 0.81, "", {
+        fontFamily: SERIF,
+        fontSize: "18px",
+        color: "#6688aa",
+      })
+      .setOrigin(0.5);
+
     /* ── start button ── */
     this.startBtn = this.add
-      .text(width / 2, height * 0.60, "─  スタート  ─", {
+      .text(width / 2, height * 0.88, "─  スタート  ─", {
         fontFamily: SERIF,
         fontSize: "28px",
         color: "#44ff88",
@@ -100,97 +126,316 @@ export class CPScreen extends Phaser.Scene {
       this.startBtn.postFX.addGlow(0x22aa55, 4, 0, false, 0.1, 8);
     }
 
-    /* ── goal button ── */
-    this.goalBtn = this.add
-      .text(width / 2, height * 0.72, "[ ゴール ]", {
+    /* ── stop button ── */
+    this.stopBtn = this.add
+      .text(width / 2, height * 0.88, "[ ストップ ]", {
         fontFamily: SERIF,
         fontSize: "22px",
         color: "#555555",
         letterSpacing: 4,
       })
       .setOrigin(0.5)
-      .on("pointerdown", () => this.handleGoal());
+      .on("pointerdown", () => this.handleStop());
 
     /* ── back button ── */
     this.add
-      .text(width / 2, height * 0.87, "[ ホームへ戻る ]", {
+      .text(width / 2, height * 0.95, "[ ホームへ戻る ]", {
         fontFamily: SERIF,
         fontSize: "18px",
         color: "#6688aa",
       })
       .setOrigin(0.5)
       .setInteractive({ useHandCursor: true })
-      .on("pointerdown", () => this.scene.start("HomeScreen"));
+      .on("pointerdown", () => this.goHome());
 
     this.applyPhase();
+
+    /* WebSocket メッセージハンドラを登録 */
+    net.onMessage((msg: ServerMsg) => this.handleServerMsg(msg));
   }
 
-  private handleStart(): void {
+  /* ------------------------------------------------------------------ */
+  /*  Navigation                                                        */
+  /* ------------------------------------------------------------------ */
+
+  private goHome(): void {
+    this.cleanup();
+    this.scene.start("HomeScreen");
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Server message handler                                            */
+  /* ------------------------------------------------------------------ */
+
+  private handleServerMsg(msg: ServerMsg): void {
+    switch (msg.type) {
+      case "cp_started":
+        this.phase = "measuring";
+        this.applyPhase();
+        this.setStatus("計測中... 歩いてください", "#44ff88");
+        this.startWatching();
+        break;
+
+      case "cp_progress": {
+        const p = msg.payload;
+        this.estimatedDist = p.estimatedDist;
+        this.pointsRecorded = p.pointsRecorded;
+        this.distText.setText(
+          `距離: ${Math.round(this.estimatedDist)} m  (${this.pointsRecorded} 点記録)`,
+        );
+        break;
+      }
+
+      case "cp_result": {
+        const r = msg.payload;
+        this.phase = "done";
+        this.applyPhase();
+        this.stopWatching();
+        this.setStatus(
+          `距離: ${Math.round(r.distance)} m  /  +${r.earned} CP\n合計 ${r.total} CP`,
+          "#44ff88",
+        );
+        this.distText.setText("");
+        this.cpDisplayText.setText(`所持 CP: ${r.total}`);
+        // 軌跡をまとめて描画
+        if (r.positions && r.positions.length > 0) {
+          this.trackCoords = r.positions.map((p) => [p.lon, p.lat] as [number, number]);
+          this.drawTrack();
+        }
+        break;
+      }
+
+      case "cp_error": {
+        const e = msg.payload;
+        this.setStatus(`エラー: ${e.message}`, "#ff6666");
+        if (this.phase === "connecting") {
+          this.phase = "idle";
+          this.applyPhase();
+        }
+        break;
+      }
+
+      case "cp_balance_result":
+        this.cpDisplayText.setText(`所持 CP: ${msg.payload.total}`);
+        break;
+    }
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Start / Stop                                                      */
+  /* ------------------------------------------------------------------ */
+
+  private async handleStart(): Promise<void> {
     if (this.phase !== "idle" && this.phase !== "done") return;
     if (!navigator.geolocation) {
       this.setStatus("位置情報が利用できません", "#ff6666");
       return;
     }
 
-    this.phase = "measuring";
+    this.phase = "connecting";
     this.applyPhase();
-    this.setStatus("現在地を取得中...", "#ffdd44");
+    this.setStatus("接続中...", "#ffdd44");
+    this.estimatedDist = 0;
+    this.pointsRecorded = 0;
+    this.trackCoords = [];
+    this.distText.setText("");
 
-    navigator.geolocation.getCurrentPosition(
-      (pos) => {
-        this.startCoords = { lat: pos.coords.latitude, lon: pos.coords.longitude };
-        this.setStatus("計測中... 目的地へ移動して [ ゴール ] を押してください", "#44ff88");
-      },
-      (err) => {
-        this.phase = "idle";
-        this.applyPhase();
-        this.setStatus(`位置情報エラー: ${err.message}`, "#ff6666");
-      },
-      { enableHighAccuracy: true, timeout: GEO_TIMEOUT_MS },
+    try {
+      if (!net.isOpen()) await net.connect();
+      // cp_start はサーバーが cp_started で応答する
+      net.send({ type: "cp_start", payload: {} });
+    } catch {
+      this.phase = "idle";
+      this.applyPhase();
+      this.setStatus("サーバー接続に失敗しました", "#ff6666");
+    }
+  }
+
+  private handleStop(): void {
+    if (this.phase !== "measuring") return;
+    this.setStatus("結果を計算中...", "#ffdd44");
+    this.stopWatching();
+    net.send({ type: "cp_stop", payload: {} });
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  GPS watch                                                         */
+  /* ------------------------------------------------------------------ */
+
+  private startWatching(): void {
+    this.stopWatching();
+    this.lastSendTime = 0;
+    this.initMap();
+
+    this.watchId = navigator.geolocation.watchPosition(
+      (pos) => this.onPosition(pos),
+      (err) => this.setStatus(`GPS エラー: ${err.message}`, "#ff6666"),
+      { enableHighAccuracy: true, maximumAge: 0 },
     );
   }
 
-  private handleGoal(): void {
-    if (this.phase !== "measuring" || !this.startCoords) return;
-
-    this.phase = "finalizing";
-    this.applyPhase();
-    this.setStatus("終了地点を取得中...", "#ffdd44");
-
-    navigator.geolocation.getCurrentPosition(
-      (pos) => {
-        const dist = this.haversineMeters(
-          this.startCoords!.lat,
-          this.startCoords!.lon,
-          pos.coords.latitude,
-          pos.coords.longitude,
-        );
-        const earned = Math.min(
-          Math.floor(dist / METERS_PER_CP),
-          MAX_EARN_PER_SESSION,
-        );
-        const newTotal = earned > 0 ? addCp(earned) : loadCp();
-        this.cpDisplayText.setText(`所持 CP: ${newTotal}`);
-        this.setStatus(
-          `距離: ${Math.round(dist)} m  /  +${earned} CP\n合計 ${newTotal} CP`,
-          "#44ff88",
-        );
-        this.startCoords = null;
-        this.phase = "done";
-        this.applyPhase();
-      },
-      (err) => {
-        this.phase = "measuring";
-        this.applyPhase();
-        this.setStatus(`位置情報エラー: ${err.message}`, "#ff6666");
-      },
-      { enableHighAccuracy: true, timeout: GEO_TIMEOUT_MS },
-    );
+  private stopWatching(): void {
+    if (this.watchId !== null) {
+      navigator.geolocation.clearWatch(this.watchId);
+      this.watchId = null;
+    }
   }
 
-  /** UI state derived from phase. Buttons' enable/disable live here only. */
+  private onPosition(pos: GeolocationPosition): void {
+    const { latitude: lat, longitude: lon, accuracy: acc } = pos.coords;
+
+    // 地図の現在地マーカーを更新
+    this.updateMapPosition(lon, lat);
+
+    // スロットル: UPDATE_INTERVAL_MS 以内なら送信しない
+    const now = Date.now();
+    if (now - this.lastSendTime < UPDATE_INTERVAL_MS) return;
+    this.lastSendTime = now;
+
+    // サーバーに送信（精度フィルタはサーバー側で行う）
+    net.send({ type: "cp_update", payload: { lat, lon, acc } });
+
+    // 軌跡にローカルでも追加（リアルタイム描画用）
+    this.trackCoords.push([lon, lat]);
+    this.drawTrack();
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Map (MapLibre GL JS)                                              */
+  /* ------------------------------------------------------------------ */
+
+  private async initMap(): Promise<void> {
+    this.destroyMap();
+
+    const container = document.getElementById("cp-map");
+    if (!container) return;
+    container.style.display = "block";
+
+    // まず現在地を1回取得してから地図を初期化する
+    const startPos = await new Promise<GeolocationPosition>((resolve, reject) => {
+      navigator.geolocation.getCurrentPosition(resolve, reject, {
+        enableHighAccuracy: true,
+        timeout: 10_000,
+      });
+    }).catch(() => null);
+
+    const center: [number, number] = startPos
+      ? [startPos.coords.longitude, startPos.coords.latitude]
+      : [139.7671, 35.6812]; // fallback: 東京駅
+
+    // AWS Location Service の地図スタイルURLを取得
+    let style: string | maplibregl.StyleSpecification =
+      `https://demotiles.maplibre.org/style.json`; // fallback
+
+    try {
+      const res = await fetch("/api/map-key");
+      if (res.ok) {
+        const data: { mapName: string; region: string; apiKey: string } = await res.json();
+        if (data.apiKey && data.mapName && data.region) {
+          style = `https://maps.geo.${data.region}.amazonaws.com/maps/v0/maps/${data.mapName}/style-descriptor?key=${data.apiKey}`;
+        }
+      }
+    } catch {
+      // fallback
+    }
+
+    this.map = new maplibregl.Map({
+      container,
+      style,
+      center,
+      zoom: 16,
+      attributionControl: false,
+    });
+
+    this.map.addControl(new maplibregl.NavigationControl(), "top-right");
+
+    // 現在地マーカー
+    const el = document.createElement("div");
+    el.style.width = "16px";
+    el.style.height = "16px";
+    el.style.borderRadius = "50%";
+    el.style.background = "#44ff88";
+    el.style.border = "3px solid #fff";
+    el.style.boxShadow = "0 0 8px rgba(68,255,136,0.6)";
+    this.userMarker = new maplibregl.Marker({ element: el })
+      .setLngLat(center)
+      .addTo(this.map);
+
+    // 地図読み込み後に軌跡ソースを追加
+    this.map.on("load", () => {
+      if (!this.map) return;
+      this.map.addSource("track", {
+        type: "geojson",
+        data: { type: "Feature", geometry: { type: "LineString", coordinates: [] }, properties: {} },
+      });
+      this.map.addLayer({
+        id: "track-line",
+        type: "line",
+        source: "track",
+        paint: {
+          "line-color": "#44ff88",
+          "line-width": 4,
+          "line-opacity": 0.8,
+        },
+      });
+    });
+  }
+
+  private updateMapPosition(lon: number, lat: number): void {
+    if (this.userMarker) {
+      this.userMarker.setLngLat([lon, lat]);
+    }
+    if (this.map) {
+      this.map.easeTo({ center: [lon, lat], duration: 500 });
+    }
+  }
+
+  private drawTrack(): void {
+    if (!this.map) return;
+    const source = this.map.getSource("track") as maplibregl.GeoJSONSource | undefined;
+    if (source) {
+      source.setData({
+        type: "Feature",
+        geometry: { type: "LineString", coordinates: this.trackCoords },
+        properties: {},
+      });
+    }
+  }
+
+  private destroyMap(): void {
+    const container = document.getElementById("cp-map");
+    if (container) container.style.display = "none";
+
+    if (this.userMarker) {
+      this.userMarker.remove();
+      this.userMarker = null;
+    }
+    if (this.map) {
+      this.map.remove();
+      this.map = null;
+    }
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  Cleanup                                                           */
+  /* ------------------------------------------------------------------ */
+
+  private cleanup(): void {
+    this.stopWatching();
+    this.destroyMap();
+    // 計測中に離脱した場合、サーバー側で自動終了される
+  }
+
+  /* ------------------------------------------------------------------ */
+  /*  UI helpers                                                        */
+  /* ------------------------------------------------------------------ */
+
   private applyPhase(): void {
-    const setEnabled = (btn: Phaser.GameObjects.Text, enabled: boolean, activeColor: string) => {
+    const setEnabled = (
+      btn: Phaser.GameObjects.Text,
+      enabled: boolean,
+      activeColor: string,
+    ) => {
       if (enabled) {
         btn.setInteractive({ useHandCursor: true }).setColor(activeColor);
       } else {
@@ -200,36 +445,28 @@ export class CPScreen extends Phaser.Scene {
 
     switch (this.phase) {
       case "idle":
-        setEnabled(this.startBtn, true, "#44ff88");
-        setEnabled(this.goalBtn, false, "#ffaa44");
-        break;
-      case "measuring":
-        setEnabled(this.startBtn, false, "#44ff88");
-        setEnabled(this.goalBtn, true, "#ffaa44");
-        break;
-      case "finalizing":
-        setEnabled(this.startBtn, false, "#44ff88");
-        setEnabled(this.goalBtn, false, "#ffaa44");
-        break;
       case "done":
         setEnabled(this.startBtn, true, "#44ff88");
-        setEnabled(this.goalBtn, false, "#ffaa44");
+        setEnabled(this.stopBtn, false, "#ffaa44");
+        this.startBtn.setVisible(true);
+        this.stopBtn.setVisible(false);
+        break;
+      case "connecting":
+        setEnabled(this.startBtn, false, "#44ff88");
+        setEnabled(this.stopBtn, false, "#ffaa44");
+        this.startBtn.setVisible(true);
+        this.stopBtn.setVisible(false);
+        break;
+      case "measuring":
+        this.startBtn.setVisible(false);
+        this.stopBtn.setVisible(true);
+        setEnabled(this.startBtn, false, "#44ff88");
+        setEnabled(this.stopBtn, true, "#ffaa44");
         break;
     }
   }
 
   private setStatus(msg: string, color: string): void {
     this.statusText.setText(msg).setColor(color);
-  }
-
-  private haversineMeters(lat1: number, lon1: number, lat2: number, lon2: number): number {
-    const R = 6371000;
-    const toRad = (d: number) => (d * Math.PI) / 180;
-    const dLat = toRad(lat2 - lat1);
-    const dLon = toRad(lon2 - lon1);
-    const a =
-      Math.sin(dLat / 2) ** 2 +
-      Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
-    return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
   }
 }

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -14,7 +14,11 @@ export default defineConfig({
       "/ws": {
         target: "ws://127.0.0.1:8080",
         ws: true,
-        changeOrigin: true, // プロキシ先とオリジンが異なる場合の遅延を防止
+        changeOrigin: true,
+      },
+      "/api": {
+        target: "http://127.0.0.1:8080",
+        changeOrigin: true,
       },
     },
   },


### PR DESCRIPTION
- CPScreenをローカル2点計測からWebSocket API (cp_start/cp_update/cp_stop) 経由に変更
  - サーバー側の静止フィルタ・速度フィルタ・精度チェックが適用されるようになり、 ユーザーが動いていないのに距離が加算される問題を修正
- MapLibre GL JSによるAWS Location Service地図をCP画面上部に表示
  - 現在地マーカーのリアルタイム更新と歩行軌跡のポリライン描画
- protocol.tsにCP関連メッセージ型 (cp_started, cp_progress, cp_result等) を追加
- vite.config.tsに/apiプロキシを追加