### PR TITLE
Person 3: 全画面のボタンスタイルとテキスト視認性を統一

### DIFF
--- a/client/src/ui/screens/CPScreen.ts
+++ b/client/src/ui/screens/CPScreen.ts
@@ -48,7 +48,7 @@ export class CPScreen extends Phaser.Scene {
     this.instructionText = this.add.text(
       0,
       0,
-      `スタート地点で [ スタート ]、目的地で [ ゴール ] を押してください\n移動距離 ${METERS_PER_CP} m につき 1 CP (1 回最大 ${MAX_EARN_PER_SESSION} CP)`,
+      `スタート地点で「スタート」、目的地で「ゴール」を押してください\n移動距離 ${METERS_PER_CP} m につき 1 CP (1 回最大 ${MAX_EARN_PER_SESSION} CP)`,
       {
         fontFamily: SERIF,
         fontSize: "15px",
@@ -64,33 +64,14 @@ export class CPScreen extends Phaser.Scene {
       color: "#4a6a8a",
     }).setOrigin(0.5);
 
-    this.startBtn = this.add.text(0, 0, "─  スタート  ─", {
-      fontFamily: SERIF,
-      fontSize: "28px",
-      color: "#44ff88",
-      letterSpacing: 8,
-    })
-      .setOrigin(0.5)
-      .setInteractive({ useHandCursor: true })
-      .on("pointerdown", () => this.handleStart());
+    this.startBtn = this.styledButton("─  スタート  ─", "28px", "#44ff88", "#88ffbb", 0x22aa55, 8);
+    this.startBtn.on("pointerdown", () => this.handleStart());
 
-    this.goalBtn = this.add.text(0, 0, "[ ゴール ]", {
-      fontFamily: SERIF,
-      fontSize: "22px",
-      color: "#555555",
-      letterSpacing: 4,
-    })
-      .setOrigin(0.5)
-      .on("pointerdown", () => this.handleGoal());
+    this.goalBtn = this.styledButton("─  ゴール  ─", "22px", "#555555", "#88aacc", 0x446688, 4);
+    this.goalBtn.on("pointerdown", () => this.handleGoal());
 
-    this.backBtn = this.add.text(0, 0, "[ ホームへ戻る ]", {
-      fontFamily: SERIF,
-      fontSize: "18px",
-      color: "#6688aa",
-    })
-      .setOrigin(0.5)
-      .setInteractive({ useHandCursor: true })
-      .on("pointerdown", () => this.scene.start("HomeScreen"));
+    this.backBtn = this.styledButton("─  ホームへ戻る  ─", "18px", "#6688aa", "#88bbdd", 0x446688, 4);
+    this.backBtn.on("pointerdown", () => this.scene.start("HomeScreen"));
 
     this.layout(this.scale.width, this.scale.height);
 
@@ -104,6 +85,32 @@ export class CPScreen extends Phaser.Scene {
     });
 
     this.applyPhase();
+  }
+
+  private styledButton(
+    label: string, fontSize: string, color: string, hoverColor: string, glowColor: number, letterSpacing: number,
+  ): Phaser.GameObjects.Text {
+    const btn = this.add.text(0, 0, label, {
+      fontFamily: SERIF,
+      fontSize,
+      color,
+      letterSpacing,
+    })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true })
+      .on("pointerover", () => {
+        btn.setColor(hoverColor);
+        if (btn.postFX) { btn.postFX.clear(); btn.postFX.addGlow(glowColor, 6, 0, false, 0.1, 12); }
+      })
+      .on("pointerout", () => {
+        btn.setColor(color);
+        if (btn.postFX) { btn.postFX.clear(); btn.postFX.addGlow(glowColor, 3, 0, false, 0.1, 8); }
+      });
+
+    if (btn.postFX) {
+      btn.postFX.addGlow(glowColor, 3, 0, false, 0.1, 8);
+    }
+    return btn;
   }
 
   private layout(width: number, height: number): void {
@@ -141,7 +148,7 @@ export class CPScreen extends Phaser.Scene {
     navigator.geolocation.getCurrentPosition(
       (pos) => {
         this.startCoords = { lat: pos.coords.latitude, lon: pos.coords.longitude };
-        this.setStatus("計測中... 目的地へ移動して [ ゴール ] を押してください", "#44ff88");
+        this.setStatus("計測中... 目的地へ移動して「ゴール」を押してください", "#44ff88");
       },
       (err) => {
         this.phase = "idle";

--- a/client/src/ui/screens/DeathScreen.ts
+++ b/client/src/ui/screens/DeathScreen.ts
@@ -91,7 +91,7 @@ export class DeathScreen extends Phaser.Scene {
       ease: "Power1",
     });
 
-    this.returnBtn = this.add.text(0, 0, "ホームへ戻る", {
+    this.returnBtn = this.add.text(0, 0, "─  ホームへ戻る  ─", {
       fontFamily: "'Times New Roman', 'Georgia', serif",
       fontSize: "20px",
       color: "#665544",
@@ -100,9 +100,19 @@ export class DeathScreen extends Phaser.Scene {
       .setOrigin(0.5)
       .setAlpha(0)
       .setInteractive({ useHandCursor: true })
-      .on("pointerover", () => this.returnBtn.setColor("#ccaa88"))
-      .on("pointerout", () => this.returnBtn.setColor("#665544"))
+      .on("pointerover", () => {
+        this.returnBtn.setColor("#ccaa88");
+        if (this.returnBtn.postFX) { this.returnBtn.postFX.clear(); this.returnBtn.postFX.addGlow(0x665544, 6, 0, false, 0.1, 12); }
+      })
+      .on("pointerout", () => {
+        this.returnBtn.setColor("#665544");
+        if (this.returnBtn.postFX) { this.returnBtn.postFX.clear(); this.returnBtn.postFX.addGlow(0x665544, 3, 0, false, 0.1, 8); }
+      })
       .on("pointerdown", () => this.scene.start("HomeScreen"));
+
+    if (this.returnBtn.postFX) {
+      this.returnBtn.postFX.addGlow(0x665544, 3, 0, false, 0.1, 8);
+    }
 
     this.tweens.add({
       targets: this.returnBtn,

--- a/client/src/ui/screens/HomeScreen.ts
+++ b/client/src/ui/screens/HomeScreen.ts
@@ -42,8 +42,8 @@ export class HomeScreen extends Phaser.Scene {
 
     this.subtitleText = this.add.text(0, 0, `ようこそ、${this.playerName}`, {
       fontFamily: SERIF,
-      fontSize: "16px",
-      color: "#4a6a8a",
+      fontSize: "24px",
+      color: "#88aacc",
       letterSpacing: 6,
     }).setOrigin(0.5);
 
@@ -57,40 +57,19 @@ export class HomeScreen extends Phaser.Scene {
       color: "#6688aa",
     }).setOrigin(0.5);
 
-    this.playBtn = this.add.text(0, 0, "─  P L A Y  ─", {
-      fontFamily: SERIF,
-      fontSize: "28px",
-      color: "#44ff88",
-      letterSpacing: 8,
-    })
-      .setOrigin(0.5)
-      .setInteractive({ useHandCursor: true })
-      .on("pointerover", () => this.playBtn.setColor("#88ffbb"))
-      .on("pointerout", () => this.playBtn.setColor("#44ff88"))
-      .on("pointerdown", () => this.tryStart());
+    this.playBtn = this.styledButton("─  P L A Y  ─", "28px", "#44ff88", "#88ffbb", 0x22aa55, 8);
+    this.playBtn.on("pointerdown", () => this.tryStart());
 
     this.input.keyboard?.on("keydown-ENTER", () => this.tryStart());
 
-    this.cpBtn = this.add.text(0, 0, "[ CP 獲得 ]", {
-      fontFamily: SERIF,
-      fontSize: "22px",
-      color: "#ffaa44",
-    })
-      .setOrigin(0.5)
-      .setInteractive({ useHandCursor: true })
-      .on("pointerdown", () => this.scene.start("CPScreen"));
+    this.cpBtn = this.styledButton("─  C P 獲 得  ─", "22px", "#ffaa44", "#ffcc88", 0xaa7722, 6);
+    this.cpBtn.on("pointerdown", () => this.scene.start("CPScreen"));
 
-    this.logoutBtn = this.add.text(0, 0, "[ ログアウト ]", {
-      fontFamily: SERIF,
-      fontSize: "18px",
-      color: "#ff6666",
-    })
-      .setOrigin(0.5)
-      .setInteractive({ useHandCursor: true })
-      .on("pointerdown", () => {
-        logout();
-        this.scene.start("LoginScreen");
-      });
+    this.logoutBtn = this.styledButton("─  ログアウト  ─", "18px", "#884444", "#ff6666", 0x882222, 4);
+    this.logoutBtn.on("pointerdown", () => {
+      logout();
+      this.scene.start("LoginScreen");
+    });
 
     this.layout(this.scale.width, this.scale.height);
 
@@ -174,6 +153,32 @@ export class HomeScreen extends Phaser.Scene {
         btn.setStroke("#000000", 0);
       }
     });
+  }
+
+  private styledButton(
+    label: string, fontSize: string, color: string, hoverColor: string, glowColor: number, letterSpacing: number,
+  ): Phaser.GameObjects.Text {
+    const btn = this.add.text(0, 0, label, {
+      fontFamily: SERIF,
+      fontSize,
+      color,
+      letterSpacing,
+    })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true })
+      .on("pointerover", () => {
+        btn.setColor(hoverColor);
+        if (btn.postFX) { btn.postFX.clear(); btn.postFX.addGlow(glowColor, 6, 0, false, 0.1, 12); }
+      })
+      .on("pointerout", () => {
+        btn.setColor(color);
+        if (btn.postFX) { btn.postFX.clear(); btn.postFX.addGlow(glowColor, 3, 0, false, 0.1, 8); }
+      });
+
+    if (btn.postFX) {
+      btn.postFX.addGlow(glowColor, 3, 0, false, 0.1, 8);
+    }
+    return btn;
   }
 
   private async tryStart(): Promise<void> {

--- a/client/src/ui/screens/LoginScreen.ts
+++ b/client/src/ui/screens/LoginScreen.ts
@@ -35,7 +35,8 @@ export class LoginScreen extends Phaser.Scene {
 
     this.subtitleText = this.add.text(0, 0, "Sign in to dive", {
       fontFamily: SERIF,
-      color: "#4a6a8a",
+      fontSize: "22px",
+      color: "#88aacc",
       letterSpacing: 6,
     }).setOrigin(0.5);
 
@@ -50,24 +51,11 @@ export class LoginScreen extends Phaser.Scene {
       align: "center",
     }).setOrigin(0.5);
 
-    this.loginBtn = this.add.text(0, 0, "─  ログイン  ─", {
-      fontFamily: SERIF,
-      color: "#44ff88",
-      letterSpacing: 8,
-    })
-      .setOrigin(0.5)
-      .setInteractive({ useHandCursor: true })
-      .on("pointerover", () => this.loginBtn.setColor("#88ffbb"))
-      .on("pointerout", () => this.loginBtn.setColor("#44ff88"))
-      .on("pointerdown", () => this.handleLogin());
+    this.loginBtn = this.styledButton("─  ログイン  ─", "24px", "#44ff88", "#88ffbb", 0x22aa55, 8);
+    this.loginBtn.on("pointerdown", () => this.handleLogin());
 
-    this.registerBtn = this.add.text(0, 0, "[ 新規登録 ]", {
-      fontFamily: SERIF,
-      color: "#ffaa44",
-    })
-      .setOrigin(0.5)
-      .setInteractive({ useHandCursor: true })
-      .on("pointerdown", () => this.handleRegister());
+    this.registerBtn = this.styledButton("─  新規登録  ─", "18px", "#ffaa44", "#ffcc88", 0xaa7722, 6);
+    this.registerBtn.on("pointerdown", () => this.handleRegister());
 
     this.layout(this.scale.width, this.scale.height);
 
@@ -86,6 +74,32 @@ export class LoginScreen extends Phaser.Scene {
       this.nameInput.remove();
       this.passwordInput.remove();
     });
+  }
+
+  private styledButton(
+    label: string, fontSize: string, color: string, hoverColor: string, glowColor: number, letterSpacing: number,
+  ): Phaser.GameObjects.Text {
+    const btn = this.add.text(0, 0, label, {
+      fontFamily: SERIF,
+      fontSize,
+      color,
+      letterSpacing,
+    })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true })
+      .on("pointerover", () => {
+        btn.setColor(hoverColor);
+        if (btn.postFX) { btn.postFX.clear(); btn.postFX.addGlow(glowColor, 6, 0, false, 0.1, 12); }
+      })
+      .on("pointerout", () => {
+        btn.setColor(color);
+        if (btn.postFX) { btn.postFX.clear(); btn.postFX.addGlow(glowColor, 3, 0, false, 0.1, 8); }
+      });
+
+    if (btn.postFX) {
+      btn.postFX.addGlow(glowColor, 3, 0, false, 0.1, 8);
+    }
+    return btn;
   }
 
   private layout(width: number, height: number): void {


### PR DESCRIPTION
## Summary
全画面のボタンを「─  ...  ─」スタイルに統一し、グロー + ホバー演出を追加。視認性の低いテキストも改善。

## 変更内容

### ボタンスタイル統一
- `[ ... ]` スタイルを全廃止 → `─  ...  ─` に統一
- 全ボタンに常時グロー（薄い発光）+ ホバー時にグロー強化 + 文字色変化

### テキスト視認性改善
- LoginScreen: 「Sign in to dive」22px / #88aacc に拡大・明色化
- HomeScreen: 「ようこそ、〇〇」24px / #88aacc に拡大・明色化

### 対象画面
- LoginScreen（ログイン / 新規登録）
- HomeScreen（PLAY / CP獲得 / ログアウト）
- CPScreen（スタート / ゴール / ホームへ戻る）
- DeathScreen（ホームへ戻る）

## Test plan
- [x] 各画面のボタンにホバーすると色が明るくなりグローが強まる
- [x] ホバー解除で元に戻る
- [x] テキストが視認しやすい