### PR TITLE
Person 3: ガイド画面を追加（進化系統・ルール）

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -4,6 +4,7 @@ import { HomeScreen } from "./ui/screens/HomeScreen";
 import { CPScreen } from "./ui/screens/CPScreen";
 import { GameScene } from "./game/scenes/GameScene";
 import { DeathScreen } from "./ui/screens/DeathScreen";
+import { GuideScreen } from "./ui/screens/GuideScreen";
 
 const config: Phaser.Types.Core.GameConfig = {
   type: Phaser.AUTO,
@@ -14,7 +15,7 @@ const config: Phaser.Types.Core.GameConfig = {
     width: "100%",
     height: "100%",
   },
-  scene: [LoginScreen, HomeScreen, CPScreen, GameScene, DeathScreen],
+  scene: [LoginScreen, HomeScreen, CPScreen, GuideScreen, GameScene, DeathScreen],
 };
 
 const game = new Phaser.Game(config);

--- a/client/src/ui/screens/GuideScreen.ts
+++ b/client/src/ui/screens/GuideScreen.ts
@@ -1,0 +1,166 @@
+import Phaser from "phaser";
+
+const SERIF = "'Times New Roman', 'Georgia', serif";
+
+const ROUTES = [
+  {
+    name: "攻撃系",
+    color: "#ff6666",
+    glowColor: 0xaa3333,
+    sharks: ["シュモクザメ", "イタチザメ", "アオザメ", "ホオジロザメ", "メガロドン"],
+    desc: "速度と攻撃力に特化。燃費が悪く、上位種ほどエサを大量に必要とする。\nメガロドンは「血の知覚」で他サメの方向を常時感知できる。",
+  },
+  {
+    name: "非攻撃系",
+    color: "#66ccff",
+    glowColor: 0x336699,
+    sharks: ["ドチザメ", "ネムリブカ", "シロワニ", "ウバザメ", "ジンベエザメ"],
+    desc: "耐久力と燃費に特化。安定したプレイスタイル。\nシロワニは1日サバ1匹で満足するほどの超燃費型。",
+  },
+  {
+    name: "深海魚系",
+    color: "#bb66ff",
+    glowColor: 0x663399,
+    sharks: ["ツラナガコビトザメ", "ノコギリザメ", "ラブカ", "ミツクリザメ", "ニシオンデンザメ"],
+    desc: "序盤は弱いが最上位が非常に強力なロマン型。\nニシオンデンザメはエサ不要で自動成長、探索範囲最大。",
+  },
+];
+
+const RULES = [
+  "鼻（頭の先端）が相手の体節に当たると自分が死亡",
+  "上位種でも鼻は弱点 ─ ジャイアントキリングが起こる",
+  "死亡するとエサに変換され、マップに散らばる",
+  "エサを食べて XP を獲得 → 閾値で進化",
+  "ダッシュで CP を消費して一時的に加速",
+];
+
+export class GuideScreen extends Phaser.Scene {
+  private backBtn!: Phaser.GameObjects.Text;
+
+  constructor() {
+    super({ key: "GuideScreen" });
+  }
+
+  create(): void {
+    const { width, height } = this.scale;
+    this.cameras.main.setBackgroundColor("#030a14");
+
+    /* ── title ── */
+    const title = this.add
+      .text(width / 2, 40, "G U I D E", {
+        fontFamily: SERIF,
+        fontSize: "36px",
+        color: "#88ccee",
+        letterSpacing: 10,
+      })
+      .setOrigin(0.5);
+
+    if (title.postFX) {
+      title.postFX.addGlow(0x225588, 4, 0, false, 0.1, 10);
+    }
+
+    /* ── scrollable content container ── */
+    let y = 90;
+
+    /* ── evolution routes ── */
+    this.add
+      .text(width / 2, y, "─  進 化 系 統  ─", {
+        fontFamily: SERIF,
+        fontSize: "22px",
+        color: "#aa8866",
+        letterSpacing: 6,
+      })
+      .setOrigin(0.5);
+    y += 40;
+
+    for (const route of ROUTES) {
+      /* route header */
+      const header = this.add
+        .text(width / 2, y, route.name, {
+          fontFamily: SERIF,
+          fontSize: "26px",
+          color: route.color,
+          letterSpacing: 6,
+        })
+        .setOrigin(0.5);
+
+      if (header.postFX) {
+        header.postFX.addGlow(route.glowColor, 5, 0, false, 0.1, 10);
+      }
+      y += 38;
+
+      /* evolution chain */
+      const chain = route.sharks.join("  →  ");
+      this.add
+        .text(width / 2, y, chain, {
+          fontFamily: SERIF,
+          fontSize: "17px",
+          color: "#ddeeff",
+          letterSpacing: 2,
+        })
+        .setOrigin(0.5);
+      y += 30;
+
+      /* description */
+      this.add
+        .text(width / 2, y, route.desc, {
+          fontFamily: SERIF,
+          fontSize: "17px",
+          color: "#bbccdd",
+          align: "center",
+          lineSpacing: 8,
+        })
+        .setOrigin(0.5, 0);
+      y += 70;
+    }
+
+    /* ── rules ── */
+    y += 10;
+    this.add
+      .text(width / 2, y, "─  ル ー ル  ─", {
+        fontFamily: SERIF,
+        fontSize: "22px",
+        color: "#aa8866",
+        letterSpacing: 6,
+      })
+      .setOrigin(0.5);
+    y += 35;
+
+    for (const rule of RULES) {
+      this.add
+        .text(width / 2, y, `◆  ${rule}`, {
+          fontFamily: SERIF,
+          fontSize: "17px",
+          color: "#bbccdd",
+          letterSpacing: 2,
+        })
+        .setOrigin(0.5);
+      y += 32;
+    }
+
+    /* ── back button ── */
+    y += 20;
+    this.backBtn = this.add
+      .text(width / 2, y, "─  戻る  ─", {
+        fontFamily: SERIF,
+        fontSize: "20px",
+        color: "#6688aa",
+        letterSpacing: 6,
+      })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true })
+      .on("pointerover", () => {
+        this.backBtn.setColor("#88bbdd");
+        if (this.backBtn.postFX) { this.backBtn.postFX.clear(); this.backBtn.postFX.addGlow(0x446688, 6, 0, false, 0.1, 12); }
+      })
+      .on("pointerout", () => {
+        this.backBtn.setColor("#6688aa");
+        if (this.backBtn.postFX) { this.backBtn.postFX.clear(); this.backBtn.postFX.addGlow(0x446688, 3, 0, false, 0.1, 8); }
+      })
+      .on("pointerdown", () => this.scene.start("HomeScreen"));
+
+    if (this.backBtn.postFX) {
+      this.backBtn.postFX.addGlow(0x446688, 3, 0, false, 0.1, 8);
+    }
+  }
+}

--- a/client/src/ui/screens/HomeScreen.ts
+++ b/client/src/ui/screens/HomeScreen.ts
@@ -15,6 +15,7 @@ export class HomeScreen extends Phaser.Scene {
   private cpText!: Phaser.GameObjects.Text;
   private playBtn!: Phaser.GameObjects.Text;
   private cpBtn!: Phaser.GameObjects.Text;
+  private guideBtn!: Phaser.GameObjects.Text;
   private logoutBtn!: Phaser.GameObjects.Text;
   private routeButtons: Phaser.GameObjects.Text[] = [];
   private resizeHandler!: (size: Phaser.Structs.Size) => void;
@@ -65,6 +66,9 @@ export class HomeScreen extends Phaser.Scene {
     this.cpBtn = this.styledButton("─  C P 獲 得  ─", "22px", "#ffaa44", "#ffcc88", 0xaa7722, 6);
     this.cpBtn.on("pointerdown", () => this.scene.start("CPScreen"));
 
+    this.guideBtn = this.styledButton("─  ガイド  ─", "20px", "#6688aa", "#88bbdd", 0x446688, 6);
+    this.guideBtn.on("pointerdown", () => this.scene.start("GuideScreen"));
+
     this.logoutBtn = this.styledButton("─  ログアウト  ─", "18px", "#884444", "#ff6666", 0x882222, 4);
     this.logoutBtn.on("pointerdown", () => {
       logout();
@@ -98,10 +102,11 @@ export class HomeScreen extends Phaser.Scene {
     this.lineGfx.strokePath();
 
     this.layoutRouteButtons(width / 2, height * 0.48);
-    this.cpText.setPosition(width / 2, height * 0.62).setText(`所持 CP: ${loadCp()}`);
-    this.playBtn.setPosition(width / 2, height * 0.70);
-    this.cpBtn.setPosition(width / 2, height * 0.80);
-    this.logoutBtn.setPosition(width / 2, height * 0.88);
+    this.cpText.setPosition(width / 2, height * 0.58).setText(`所持 CP: ${loadCp()}`);
+    this.playBtn.setPosition(width / 2, height * 0.65);
+    this.cpBtn.setPosition(width / 2, height * 0.73);
+    this.guideBtn.setPosition(width / 2, height * 0.81);
+    this.logoutBtn.setPosition(width / 2, height * 0.89);
   }
 
   private createRouteButtons(): void {


### PR DESCRIPTION
## Summary
ホーム画面に「ガイド」ボタンを追加し、進化系統とゲームルールを確認できる新画面を作成。

## 変更内容
- **GuideScreen（新規）**: 進化系統 3 ルートの進化チェーン・特徴説明 + 基本ルール一覧
- **HomeScreen**: 「─ ガイド ─」ボタン追加、レイアウト調整
- **main.ts**: GuideScreen をシーン登録

## ガイド画面の内容
### 進化系統
- 攻撃系: シュモクザメ → イタチザメ → アオザメ → ホオジロザメ → メガロドン
- 非攻撃系: ドチザメ → ネムリブカ → シロワニ → ウバザメ → ジンベエザメ
- 深海魚系: ツラナガコビトザメ → ノコギリザメ → ラブカ → ミツクリザメ → ニシオンデンザメ

### ルール
- 鼻が弱点（ジャイアントキリングあり）
- 死亡時エサ化
- XP で進化
- ダッシュで CP 消費

## Test plan
- [x] ホーム画面から「ガイド」→ ガイド画面が表示される
- [x] 「戻る」→ ホーム画面に戻る
- [x] テキストが読みやすいサイズ・色で表示される