### PR TITLE
fix(cp): CP専用WebSocket接続を分離しサメ生成を完全に防止

### DIFF
--- a/client/src/network/cp-websocket.ts
+++ b/client/src/network/cp-websocket.ts
@@ -1,0 +1,112 @@
+import type { ClientMsg, ServerMsg } from "./protocol";
+
+/**
+ * CP 専用の WebSocket 接続。
+ * ゲーム用の `net` シングルトンとは完全に独立しており、
+ * CP 計測中にサメが生成されたりゲーム状態に干渉することがない。
+ */
+export class CPNetClient {
+  private ws: WebSocket | null = null;
+  private handlers: Array<(m: ServerMsg) => void> = [];
+  private closeHandlers: Array<() => void> = [];
+
+  connect(): Promise<void> {
+    // 既存の接続があれば閉じる
+    this.disconnect();
+
+    return new Promise((resolve, reject) => {
+      const proto = location.protocol === "https:" ? "wss:" : "ws:";
+      const backendHost = import.meta.env.VITE_WS_URL ?? location.host;
+      const url = `${proto}//${backendHost}/ws`;
+      const ws = new WebSocket(url);
+      ws.onopen = () => {
+        this.ws = ws;
+        resolve();
+      };
+      ws.onerror = (e) => reject(e);
+      ws.onmessage = (ev) => {
+        try {
+          const raw = JSON.parse(ev.data);
+          if (
+            raw &&
+            typeof raw.type === "string" &&
+            raw.payload &&
+            typeof raw.payload === "object" &&
+            !Array.isArray(raw.payload)
+          ) {
+            const msg = raw as ServerMsg;
+            for (const h of this.handlers) h(msg);
+          }
+        } catch {
+          /* ignore malformed */
+        }
+      };
+      ws.onclose = () => {
+        this.ws = null;
+        for (const h of this.closeHandlers) h();
+      };
+    });
+  }
+
+  disconnect(): void {
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+  }
+
+  send(msg: ClientMsg): void {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) return;
+    this.ws.send(JSON.stringify(msg));
+  }
+
+  onMessage(h: (m: ServerMsg) => void): void {
+    this.handlers.push(h);
+  }
+
+  offMessage(h: (m: ServerMsg) => void): void {
+    this.handlers = this.handlers.filter((fn) => fn !== h);
+  }
+
+  onClose(h: () => void): void {
+    this.closeHandlers.push(h);
+  }
+
+  offClose(h: () => void): void {
+    this.closeHandlers = this.closeHandlers.filter((fn) => fn !== h);
+  }
+
+  /** Wait for a specific message type. Rejects after timeout or disconnect. */
+  waitFor<T extends ServerMsg["type"]>(
+    type: T,
+    timeout = 10_000,
+  ): Promise<Extract<ServerMsg, { type: T }>> {
+    return new Promise((resolve, reject) => {
+      const cleanup = () => {
+        clearTimeout(timer);
+        this.offMessage(msgHandler);
+        this.offClose(closeHandler);
+      };
+      const timer = setTimeout(() => {
+        cleanup();
+        reject(new Error(`timeout waiting for ${type}`));
+      }, timeout);
+      const msgHandler = (msg: ServerMsg) => {
+        if (msg.type === type) {
+          cleanup();
+          resolve(msg as Extract<ServerMsg, { type: T }>);
+        }
+      };
+      const closeHandler = () => {
+        cleanup();
+        reject(new Error(`disconnected while waiting for ${type}`));
+      };
+      this.handlers.push(msgHandler);
+      this.closeHandlers.push(closeHandler);
+    });
+  }
+
+  isOpen(): boolean {
+    return this.ws !== null && this.ws.readyState === WebSocket.OPEN;
+  }
+}

--- a/client/src/ui/screens/CPScreen.ts
+++ b/client/src/ui/screens/CPScreen.ts
@@ -1,7 +1,7 @@
 import Phaser from "phaser";
 import maplibregl from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
-import { net } from "../../network/websocket";
+import { CPNetClient } from "../../network/cp-websocket";
 import { loadCp, setCp } from "../../storage/cp";
 import type { ServerMsg } from "../../network/protocol";
 
@@ -36,6 +36,9 @@ export class CPScreen extends Phaser.Scene {
   private map: maplibregl.Map | null = null;
   private trackCoords: [number, number][] = [];
   private userMarker: maplibregl.Marker | null = null;
+
+  /** CP 専用 WebSocket 接続（ゲームとは独立） */
+  private cpNet = new CPNetClient();
 
   /** サーバーから受け取った最新値 */
   private estimatedDist = 0;
@@ -118,12 +121,12 @@ export class CPScreen extends Phaser.Scene {
     /* WebSocket ハンドラを登録（シーン終了時に解除） */
     this.msgHandler = (msg: ServerMsg) => this.handleServerMsg(msg);
     this.closeHandler = () => this.handleDisconnect();
-    net.onMessage(this.msgHandler);
-    net.onClose(this.closeHandler);
+    this.cpNet.onMessage(this.msgHandler);
+    this.cpNet.onClose(this.closeHandler);
 
     /* 画面表示時にサーバーから最新CP残高を取得 */
-    if (net.isOpen()) {
-      net.send({ type: "cp_balance", payload: {} });
+    if (this.cpNet.isOpen()) {
+      this.cpNet.send({ type: "cp_balance", payload: {} });
     }
   }
 
@@ -264,15 +267,12 @@ export class CPScreen extends Phaser.Scene {
     this.distText.setText("");
 
     try {
-      if (!net.isOpen()) {
-        await net.connect();
-      }
-      // サーバーは join で playerID を割り当てるため、CP操作前に必ず join を送る
-      // waitFor を send の前に登録し、welcome を確実にキャッチする
-      const welcomePromise = net.waitFor("welcome", 10_000);
-      net.send({ type: "join", payload: { name: "__cp__walker", route: "attack" } });
+      // CP 専用の独立した WebSocket 接続を開く（ゲーム接続とは別）
+      await this.cpNet.connect();
+      const welcomePromise = this.cpNet.waitFor("welcome", 10_000);
+      this.cpNet.send({ type: "join", payload: { name: "__cp__walker", route: "attack" } });
       await welcomePromise;
-      net.send({ type: "cp_start", payload: {} });
+      this.cpNet.send({ type: "cp_start", payload: {} });
     } catch {
       this.phase = "idle";
       this.applyPhase();
@@ -284,7 +284,7 @@ export class CPScreen extends Phaser.Scene {
     if (this.phase !== "measuring") return;
     this.setStatus("結果を計算中...", "#ffdd44");
     this.stopWatching();
-    net.send({ type: "cp_stop", payload: {} });
+    this.cpNet.send({ type: "cp_stop", payload: {} });
   }
 
   /* ------------------------------------------------------------------ */
@@ -322,7 +322,7 @@ export class CPScreen extends Phaser.Scene {
     this.lastSendTime = now;
 
     // サーバーに送信（精度フィルタはサーバー側で行う）
-    net.send({ type: "cp_update", payload: { lat, lon, acc } });
+    this.cpNet.send({ type: "cp_update", payload: { lat, lon, acc } });
 
     // 軌跡にローカルでも追加（リアルタイム描画用）
     this.trackCoords.push([lon, lat]);
@@ -484,13 +484,14 @@ export class CPScreen extends Phaser.Scene {
     this.stopWatching();
     this.destroyMap();
     if (this.msgHandler) {
-      net.offMessage(this.msgHandler);
+      this.cpNet.offMessage(this.msgHandler);
       this.msgHandler = null;
     }
     if (this.closeHandler) {
-      net.offClose(this.closeHandler);
+      this.cpNet.offClose(this.closeHandler);
       this.closeHandler = null;
     }
+    this.cpNet.disconnect();
   }
 
   /* ------------------------------------------------------------------ */


### PR DESCRIPTION
CPScreenがゲーム用のnetシングルトンを共有していたため、
CP計測開始時のjoinでゲームにサメが生成される問題があった。

- CPNetClientクラスを新規作成（cp-websocket.ts）
- CPScreenは独立したWebSocket接続を使用するように変更
- シーン終了時にCP専用接続を切断
- ゲーム接続とCP接続が完全に独立し互いに干渉しない