### PR TITLE
Person 3: 進化通知を一時無効化

### DIFF
--- a/client/src/game/territory/TerritoryManager.ts
+++ b/client/src/game/territory/TerritoryManager.ts
@@ -176,7 +176,7 @@ export class TerritoryManager {
     this.myLevel = newLevel;
     this.cache.setMyLevel(newLevel);
 
-    this.showSuccess(`進化しました！レベル ${newLevel}`);
+    // 進化通知は無効化（2個表示されるバグ #65 未解決のため）
 
     // Recalculate is automatically handled by TerritoryCache
   }


### PR DESCRIPTION
## Summary
進化通知（「進化しました！レベル N」）が2個表示されるバグ (#65) が未解決のため、通知テキスト表示を一時的に無効化。

進化時のカメラフラッシュ・サウンド・パルスエフェクトは引き続き動作します。

Refs: #65