### PR TITLE
モバイル: 全画面の横向き強制オーバーレイを無効化

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -59,9 +59,7 @@
         opacity: 0.7;
       }
 
-      @media (orientation: portrait) {
-        #rotate-overlay { display: flex; }
-      }
+      /* rotate-overlay is now controlled by JS (GameScene only) */
 
       #pwa-banner {
         display: none;


### PR DESCRIPTION
ゲームプレイ中のみJS制御で表示するため、CSSメディアクエリによる自動表示を削除