### PR TITLE
Person 3: 進化レベル表示をユーザー名から左上HUDに移動

### DIFF
--- a/client/src/game/hud/XpBar.ts
+++ b/client/src/game/hud/XpBar.ts
@@ -49,11 +49,10 @@ export class XpBar implements HudComponent {
 
     this.drawBar(xp, threshold);
     this.scoreText.setText(isMax ? `${xp} XP` : `${xp} / ${threshold} XP`);
-    this.stageText.setText(
-      ROUTE_STAGE_NAMES[route][
-        Math.min(stage, ROUTE_STAGE_NAMES[route].length - 1)
-      ],
-    );
+    const stageName = ROUTE_STAGE_NAMES[route][
+      Math.min(stage, ROUTE_STAGE_NAMES[route].length - 1)
+    ];
+    this.stageText.setText(`${stageName} (Lv.${stage + 1})`);
   }
 
   private drawBar(xp: number, threshold: number): void {

--- a/client/src/game/objects/Shark.ts
+++ b/client/src/game/objects/Shark.ts
@@ -141,10 +141,8 @@ export class Shark extends Phaser.GameObjects.Container {
       changedAppearance = true;
     }
 
-    if (name || changedAppearance) {
-      if (this.sharkName) {
-        this.nameText.setText(`${this.sharkName} (進化レベル${this.stage + 1})`);
-      }
+    if (name) {
+      this.nameText.setText(this.sharkName);
     }
     
     if (route !== this.route) {


### PR DESCRIPTION
## Summary
サメの頭上のユーザー名から進化レベル表示を削除し、左上HUDの種族名に移動。

## 変更内容
- `Shark.ts`: `${name} (進化レベルN)` → `${name}` のみ表示
- `XpBar.ts`: 種族名に `(Lv.N)` を追記（例: `シュモクザメ (Lv.1)`）

## Test plan
- [x] サメの頭上に名前のみ表示される
- [x] 左上に「シュモクザメ (Lv.1)」のように種族名 + レベルが表示される
- [x] 進化するとレベル数値と種族名が両方更新される