### PR TITLE
fix(radar): レーダー表示の修正（赤い餌の制御と矢印の向き）

### DIFF
--- a/client/src/game/hud/RadarRenderer.ts
+++ b/client/src/game/hud/RadarRenderer.ts
@@ -144,7 +144,7 @@ export class RadarRenderer implements HudComponent {
     }
 
     /* player direction arrow (center) - points in shark's movement direction */
-    const a = this.myAngle - Math.PI / 2; // convert from Phaser angle (0=right) to arrow pointing up when angle=0
+    const a = this.myAngle + Math.PI / 2; // adjust for radar coordinate system
     const al = 10;
     const aw = 6;
     const tipX = cx + Math.cos(a) * al;

--- a/client/src/game/hud/RadarRenderer.ts
+++ b/client/src/game/hud/RadarRenderer.ts
@@ -144,7 +144,7 @@ export class RadarRenderer implements HudComponent {
     }
 
     /* player direction arrow (center) - points in shark's movement direction */
-    const a = this.myAngle + Math.PI / 2; // adjust for radar coordinate system
+    const a = this.myAngle;
     const al = 10;
     const aw = 6;
     const tipX = cx + Math.cos(a) * al;

--- a/client/src/game/hud/RadarRenderer.ts
+++ b/client/src/game/hud/RadarRenderer.ts
@@ -1,5 +1,6 @@
 import Phaser from "phaser";
 import type { HudComponent } from "./HudComponent";
+import type { SharkRoute } from "../../network/protocol";
 
 const RADAR_R = 90;
 const RADAR_RANGE = 1400;
@@ -21,8 +22,9 @@ export class RadarRenderer implements HudComponent {
   private myX = 0;
   private myY = 0;
   private myAngle = 0;
+  private myRoute: SharkRoute = "attack";
   private sharks: RadarBlip[] = [];
-  private foods: { x: number; y: number }[] = [];
+  private foods: { x: number; y: number; isRed?: boolean }[] = [];
 
   constructor(scene: Phaser.Scene, container: Phaser.GameObjects.Container) {
     this.scaleManager = scene.scale;
@@ -36,13 +38,15 @@ export class RadarRenderer implements HudComponent {
     myX: number,
     myY: number,
     myAngle: number,
+    myRoute: SharkRoute,
     sharks: RadarBlip[],
-    foods: { x: number; y: number }[],
+    foods: { x: number; y: number; isRed?: boolean }[],
   ): void {
     this.myId = myId;
     this.myX = myX;
     this.myY = myY;
     this.myAngle = myAngle;
+    this.myRoute = myRoute;
     this.sharks = sharks;
     this.foods = foods;
   }
@@ -106,13 +110,22 @@ export class RadarRenderer implements HudComponent {
 
     const s = r / RADAR_RANGE;
 
-    /* food dots (tiny green) */
-    g.fillStyle(0x44ee88, 0.65);
+    /* food dots */
     for (const f of this.foods) {
       const dx = (f.x - this.myX) * s;
       const dy = (f.y - this.myY) * s;
       if (dx * dx + dy * dy < (r - 2) * (r - 2)) {
-        g.fillCircle(cx + dx, cy + dy, 1.5);
+        if (f.isRed) {
+          /* red food: only visible to attack sharks */
+          if (this.myRoute === "attack") {
+            g.fillStyle(0xff4444, 0.65);
+            g.fillCircle(cx + dx, cy + dy, 1.5);
+          }
+        } else {
+          /* normal food: green dot */
+          g.fillStyle(0x44ee88, 0.65);
+          g.fillCircle(cx + dx, cy + dy, 1.5);
+        }
       }
     }
 
@@ -130,8 +143,8 @@ export class RadarRenderer implements HudComponent {
       }
     }
 
-    /* player direction arrow (center) */
-    const a = this.myAngle;
+    /* player direction arrow (center) - points in shark's movement direction */
+    const a = this.myAngle - Math.PI / 2; // convert from Phaser angle (0=right) to arrow pointing up when angle=0
     const al = 10;
     const aw = 6;
     const tipX = cx + Math.cos(a) * al;

--- a/client/src/game/scenes/GameScene.ts
+++ b/client/src/game/scenes/GameScene.ts
@@ -563,14 +563,24 @@ export class GameScene extends Phaser.Scene {
       /* update radar blips */
       const sharks = this.gameState.getSharks();
       const foods = this.gameState.getFoods();
-      const mySv = sharks.get(this.myId);
+
+      // Find self in server data for angle
+      let myAngle = 0;
+      const allSharks = m.full ? m.sharks : m.updatedSharks;
+      const mySelf = allSharks?.find(s => s.id === this.myId);
+      if (mySelf) {
+        myAngle = mySelf.angle;
+      }
+
       this.radarRenderer.setBlips(
         this.myId,
         m.you.x,
         m.you.y,
-        mySv?.angle ?? 0,
-        mySv?.route ?? "attack",
-        Array.from(sharks.entries()).map(([id, sv]) => ({ id, x: sv.x, y: sv.y })),
+        myAngle,
+        this.myRoute,
+        this.myRoute === "attack"
+          ? Array.from(sharks.entries()).map(([id, sv]) => ({ id, x: sv.x, y: sv.y }))
+          : [], // non-attack sharks don't see other sharks on radar
         Array.from(foods.values()).map((fv) => ({ x: fv.x, y: fv.y, isRed: fv.isRed })),
       );
 

--- a/client/src/game/scenes/GameScene.ts
+++ b/client/src/game/scenes/GameScene.ts
@@ -569,8 +569,9 @@ export class GameScene extends Phaser.Scene {
         m.you.x,
         m.you.y,
         mySv?.angle ?? 0,
+        mySv?.route ?? "attack",
         Array.from(sharks.entries()).map(([id, sv]) => ({ id, x: sv.x, y: sv.y })),
-        Array.from(foods.values()).map((fv) => ({ x: fv.x, y: fv.y })),
+        Array.from(foods.values()).map((fv) => ({ x: fv.x, y: fv.y, isRed: fv.isRed })),
       );
 
       /* XP bar */


### PR DESCRIPTION
## Summary
- 赤い餌は攻撃種のサメのみレーダーに赤い点として表示
- 通常の餌は緑の点として全員に表示
- 攻撃種以外はレーダーに他のサメを表示しない
- レーダー中央の矢印をサメの進行方向と一致させる

## Test plan
- [ ] 攻撃種のサメでプレイし、赤い餌が赤い点として表示されることを確認
- [ ] 非攻撃種のサメでプレイし、赤い餌が表示されないことを確認
- [ ] 非攻撃種のサメで、他のサメがレーダーに表示されないことを確認
- [ ] レーダーの矢印がサメの進行方向と一致することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)