### PR TITLE
Add glowing effect to human player sprite

### DIFF
--- a/client/src/game/objects/Shark.ts
+++ b/client/src/game/objects/Shark.ts
@@ -153,6 +153,12 @@ export class Shark extends Phaser.GameObjects.Container {
         this.rope.setVisible(false);
         this.humanSprite = (this.scene as Phaser.Scene).add.sprite(0, 0, "diver");
         this.humanSprite.setScale(0.1); // 1/5 of original size (0.5 -> 0.1)
+        this.humanSprite.setAlpha(0.9);
+        this.humanSprite.setTint(0x708898);
+        // Add glow effect like food diver
+        if (this.humanSprite.postFX) {
+          this.humanSprite.postFX.addGlow(0xccaa22, 4, 0, false, 0.1, 10);
+        }
         this.add(this.humanSprite);
       } else if (route !== "human" && this.humanSprite) {
         this.humanSprite.destroy();


### PR DESCRIPTION
Apply the same visual treatment as food diver:
- Set alpha to 0.9 for slight transparency
- Apply grey tint (0x708898) for consistency
- Add golden glow effect (0xccaa22) with postFX

This makes human players more visible and consistent with the existing diver food aesthetic. The glow helps distinguish humans from the dark ocean background.